### PR TITLE
remove triggers

### DIFF
--- a/assertions-book/assertions/ass1-impl-addr-change.mdx
+++ b/assertions-book/assertions/ass1-impl-addr-change.mdx
@@ -17,7 +17,7 @@ The assertion checks if the address of a contract has changed after a transactio
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Assertion} from "../lib/credible-std/Assertion.sol";
+import {Assertion} from "../../lib/credible-std/Assertion.sol";
 
 interface IImplementation {
     function implementation() external view returns (address);
@@ -26,10 +26,9 @@ interface IImplementation {
 contract ImplementationChange is Assertion {
     IImplementation public implementation = IImplementation(address(0xbeef));
 
-    function fnSelectors() external pure override returns (Trigger[] memory) {
-        Trigger[] memory triggers = new Trigger[](1); // Define the number of triggers
-        triggers[0] = Trigger(TriggerType.STORAGE, this.implementationChange.selector); // Define the trigger
-        return triggers;
+    function fnSelectors() external pure override returns (bytes4[] memory assertions) {
+        assertions = new bytes4[](1);
+        assertions[0] = this.implementationChange.selector;
     }
 
     // Asssert that the implementation contract address doesn't change
@@ -42,4 +41,5 @@ contract ImplementationChange is Assertion {
         return preImpl == postImpl;
     }
 }
+
 ```

--- a/assertions-book/assertions/ass10-oracle-validation.mdx
+++ b/assertions-book/assertions/ass10-oracle-validation.mdx
@@ -18,10 +18,11 @@ There are two triggers, one for the liveness of the oracle and one for the price
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Assertion} from "../lib/credible-std/Assertion.sol";
+import {Assertion} from "../../lib/credible-std/Assertion.sol";
 
 interface IOracle {
     function lastUpdated() external view returns (uint256);
+
     function price() external view returns (uint256);
 }
 
@@ -29,11 +30,10 @@ interface IOracle {
 contract OracleLivenessAssertion is Assertion {
     IOracle public oracle = IOracle(address(0xbeef));
 
-    function fnSelectors() external pure override returns (Trigger[] memory) {
-        Trigger[] memory triggers = new Trigger[](2); // Define the number of triggers
-        triggers[0] = Trigger(TriggerType.STORAGE, this.assertionOracleLiveness.selector); // Define the trigger
-        triggers[1] = Trigger(TriggerType.STORAGE, this.assertionOraclePrice.selector); // Define the trigger
-        return triggers;
+    function fnSelectors() external pure override returns (bytes4[] memory assertions) {
+        assertions = new bytes4[](2);
+        assertions[0] = this.assertionOracleLiveness.selector;
+        assertions[1] = this.assertionOraclePrice.selector;
     }
 
     // Make sure that the oracle has been updated within the last 10 minutes

--- a/assertions-book/assertions/ass11-twap-deviation.mdx
+++ b/assertions-book/assertions/ass11-twap-deviation.mdx
@@ -15,10 +15,11 @@ In this example we check that the TWAP price doesn't deviate more than 5% from t
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Assertion} from "../lib/credible-std/Assertion.sol";
+import {Assertion} from "../../lib/credible-std/Assertion.sol";
 
 interface IPool {
     function price() external view returns (uint256);
+
     function twap() external view returns (uint256);
 }
 
@@ -26,10 +27,9 @@ interface IPool {
 contract TwapDeviationAssertion is Assertion {
     IPool public pool = IPool(address(0xbeef));
 
-    function fnSelectors() external pure override returns (Trigger[] memory) {
-        Trigger[] memory triggers = new Trigger[](1); // Define the number of triggers
-        triggers[0] = Trigger(TriggerType.STORAGE, this.assertionTwapDeviation.selector); // Define the trigger
-        return triggers;
+    function fnSelectors() external pure override returns (bytes4[] memory assertions) {
+        assertions = new bytes4[](1);
+        assertions[0] = this.assertionTwapDeviation.selector;
     }
 
     // Make sure that the price doesn't deviate more than 5% from the twap
@@ -45,4 +45,5 @@ contract TwapDeviationAssertion is Assertion {
         return deviation <= maxDeviation;
     }
 }
+
 ```

--- a/assertions-book/assertions/ass12-erc4626-assets-to-shares.mdx
+++ b/assertions-book/assertions/ass12-erc4626-assets-to-shares.mdx
@@ -15,7 +15,7 @@ This assertion makes sure that the total shares are not more than the total asse
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Assertion} from "../lib/credible-std/Assertion.sol";
+import {Assertion} from "../../lib/credible-std/Assertion.sol";
 
 interface IERC4626 {
     function totalAssets() external view returns (uint256);
@@ -29,10 +29,9 @@ interface IERC4626 {
 contract ERC4626AssetsSharesAssertion is Assertion {
     IERC4626 public erc4626 = IERC4626(address(0xbeef));
 
-    function fnSelectors() external pure override returns (Trigger[] memory) {
-        Trigger[] memory triggers = new Trigger[](1); // Define the number of triggers
-        triggers[0] = Trigger(TriggerType.STORAGE, this.assertionAssetsShares.selector); // Define the trigger
-        return triggers;
+    function fnSelectors() external pure override returns (bytes4[] memory assertions) {
+        assertions = new bytes4[](1);
+        assertions[0] = this.assertionAssetsShares.selector;
     }
 
     // Make sure that the total shares are not more than the total assets

--- a/assertions-book/assertions/ass13-erc4626-deposit-withdraw.mdx
+++ b/assertions-book/assertions/ass13-erc4626-deposit-withdraw.mdx
@@ -14,9 +14,10 @@ This assertion makes sure that the `deposit` and `withdraw` functions are correc
 ## Code Example
 ```solidity
 // SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Assertion} from "../lib/credible-std/Assertion.sol";
+import {Assertion} from "../../lib/credible-std/Assertion.sol";
 
 interface IERC4626 {
     function previewDeposit(uint256 assets) external view returns (uint256);
@@ -32,11 +33,10 @@ interface IERC4626 {
 contract ERC4626DepositWithdrawAssertion is Assertion {
     IERC4626 public erc4626 = IERC4626(address(0xbeef));
 
-    function fnSelectors() external pure override returns (Trigger[] memory) {
-        Trigger[] memory triggers = new Trigger[](2); // Define the number of triggers
-        triggers[0] = Trigger(TriggerType.STORAGE, this.assertionDeposit.selector); // Define the trigger
-        triggers[1] = Trigger(TriggerType.STORAGE, this.assertionWithdraw.selector); // Define the trigger
-        return triggers;
+    function fnSelectors() external pure override returns (bytes4[] memory assertions) {
+        assertions = new bytes4[](2);
+        assertions[0] = this.assertionDeposit.selector;
+        assertions[1] = this.assertionWithdraw.selector;
     }
 
     // Make sure that the preview deposit is correct

--- a/assertions-book/assertions/ass19-tokens-borrowed-invariant.mdx
+++ b/assertions-book/assertions/ass19-tokens-borrowed-invariant.mdx
@@ -17,7 +17,7 @@ Check that the tokens borrowed are not more than the tokens deposited.
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Assertion} from "../lib/credible-std/Assertion.sol";
+import {Assertion} from "../../lib/credible-std/Assertion.sol";
 
 interface IMorpho {
     function totalSupplyAsset() external view returns (uint256);
@@ -29,10 +29,9 @@ interface IMorpho {
 contract TokensBorrowedInvariant is Assertion {
     IMorpho public morpho = IMorpho(address(0xbeef));
 
-    function fnSelectors() external pure override returns (Trigger[] memory) {
-        Trigger[] memory triggers = new Trigger[](1); // Define the number of triggers
-        triggers[0] = Trigger(TriggerType.STORAGE, this.assertionBorrowedInvariant.selector); // Define the trigger
-        return triggers;
+    function fnSelectors() external pure override returns (bytes4[] memory assertions) {
+        assertions = new bytes4[](1);
+        assertions[0] = this.assertionBorrowedInvariant.selector;
     }
 
     // Check that the total supply of assets is greater than or equal to the total borrowed assets
@@ -45,5 +44,4 @@ contract TokensBorrowedInvariant is Assertion {
         return totalSupplyAsset >= totalBorrowedAsset;
     }
 }
-
 ```

--- a/assertions-book/assertions/ass5-ownership-change.mdx
+++ b/assertions-book/assertions/ass5-ownership-change.mdx
@@ -16,7 +16,7 @@ The assertion checks if the owner of a contract has changed after a transaction 
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Assertion} from "../lib/credible-std/Assertion.sol";
+import {Assertion} from "../../lib/credible-std/Assertion.sol";
 
 interface IOwnership {
     function owner() external view returns (address);
@@ -29,11 +29,10 @@ interface IOwnership {
 contract OwnerChange is Assertion {
     IOwnership public ownership = IOwnership(address(0xbeef));
 
-    function fnSelectors() external pure override returns (Trigger[] memory) {
-        Trigger[] memory triggers = new Trigger[](2); // Define the number of triggers
-        triggers[0] = Trigger(TriggerType.STORAGE, this.assertionOwnerChange.selector); // Define the trigger
-        triggers[1] = Trigger(TriggerType.STORAGE, this.assertionAdminChange.selector); // Example of another trigger
-        return triggers;
+    function fnSelectors() external pure override returns (bytes4[] memory assertions) {
+        assertions = new bytes4[](2);
+        assertions[0] = this.assertionOwnerChange.selector;
+        assertions[1] = this.assertionAdminChange.selector;
     }
 
     // This function is used to check if the owner has changed.
@@ -58,4 +57,5 @@ contract OwnerChange is Assertion {
         return preAdmin == postAdmin; // return false if the admin has changed (invalid state)
     }
 }
+
 ```

--- a/assertions-book/assertions/ass6-constant-product.mdx
+++ b/assertions-book/assertions/ass6-constant-product.mdx
@@ -14,7 +14,7 @@ The assertion checks if the constant product is maintained in an AMM pool after 
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Assertion} from "../lib/credible-std/Assertion.sol";
+import {Assertion} from "lib/credible-std/Assertion.sol";
 
 // We assume Aerodrome style pool
 interface IAmm {
@@ -26,10 +26,9 @@ interface IAmm {
 contract ConstantProductAssertion is Assertion {
     IAmm public amm = IAmm(address(0xbeef));
 
-    function fnSelectors() external pure override returns (Trigger[] memory) {
-        Trigger[] memory triggers = new Trigger[](1); // Define the number of triggers
-        triggers[0] = Trigger(TriggerType.STORAGE, this.assertionConstantProduct.selector); // Define the trigger
-        return triggers;
+    function fnSelectors() external pure override returns (bytes4[] memory assertions) {
+        assertions = new bytes4[](1);
+        assertions[0] = this.assertionConstantProduct.selector;
     }
 
     // Make sure that the product of the reserves is equal to the constant product
@@ -43,4 +42,5 @@ contract ConstantProductAssertion is Assertion {
         return k == amm.getK();
     }
 }
+
 ```

--- a/assertions-book/assertions/ass7-lending-health-factor.mdx
+++ b/assertions-book/assertions/ass7-lending-health-factor.mdx
@@ -15,7 +15,7 @@ The health factor is a measure of the riskiness of a position in a lending proto
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Assertion} from "../lib/credible-std/Assertion.sol";
+import {Assertion} from "../../lib/credible-std/Assertion.sol";
 
 // We use Morpho as an example, but this could be any lending protocol
 interface IMorpho {
@@ -32,10 +32,9 @@ interface IMorpho {
 contract LendingHealthFactorAssertion is Assertion {
     IMorpho public morpho = IMorpho(address(0xbeef));
 
-    function fnSelectors() external pure override returns (Trigger[] memory) {
-        Trigger[] memory triggers = new Trigger[](1); // Define the number of triggers
-        triggers[0] = Trigger(TriggerType.STORAGE, this.assertionHealthFactor.selector); // Define the trigger
-        return triggers;
+    function fnSelectors() external pure override returns (bytes4[] memory assertions) {
+        assertions = new bytes4[](1);
+        assertions[0] = this.assertionHealthFactor.selector;
     }
 
     // Check that the position is still healthy after the transaction

--- a/assertions-book/assertions/ass8-sum-of-all-positions.mdx
+++ b/assertions-book/assertions/ass8-sum-of-all-positions.mdx
@@ -18,7 +18,7 @@ This assertion assumes a cheatcode that allows iteration over all non-zero entri
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Assertion} from "../lib/credible-std/Assertion.sol";
+import {Assertion} from "../../lib/credible-std/Assertion.sol";
 
 // We use Morpho as an example, but this could be any lending protocol
 interface IMorpho {
@@ -29,10 +29,9 @@ interface IMorpho {
 contract PositionSumAssertion is Assertion {
     IMorpho morpho = IMorpho(address(0xbeef));
 
-    function fnSelectors() external pure override returns (Trigger[] memory) {
-        Trigger[] memory triggers = new Trigger[](1); // Define the number of triggers
-        triggers[0] = Trigger(TriggerType.STORAGE, this.assertionPositionsSum.selector); // Define the trigger
-        return triggers;
+    function fnSelectors() external pure override returns (bytes4[] memory assertions) {
+        assertions = new bytes4[](1);
+        assertions[0] = this.assertionPositionsSum.selector;
     }
 
     // Compare the sum of all positions to the total supply reported by the protocol

--- a/assertions-book/assertions/ass9-timelock-verification.mdx
+++ b/assertions-book/assertions/ass9-timelock-verification.mdx
@@ -16,7 +16,7 @@ It also check that the admin is the same as the pre-state admin.
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Assertion} from "../lib/credible-std/Assertion.sol";
+import {Assertion} from "../../lib/credible-std/Assertion.sol";
 
 interface IGovernance {
     struct Timelock {
@@ -32,10 +32,9 @@ interface IGovernance {
 contract TimelockVerification is Assertion {
     IGovernance governance = IGovernance(address(0xbeef));
 
-    function fnSelectors() external pure override returns (Trigger[] memory) {
-        Trigger[] memory triggers = new Trigger[](1); // Define the number of triggers
-        triggers[0] = Trigger(TriggerType.STORAGE, this.assertionTimelock.selector); // Define the trigger
-        return triggers;
+    function fnSelectors() external pure override returns (bytes4[] memory assertions) {
+        assertions = new bytes4[](1);
+        assertions[0] = this.assertionTimelock.selector;
     }
 
     // This assertion checks that if a timelock is activated that it's within the correct parameters


### PR DESCRIPTION
We don't use triggers in the fnSelectors() function anymore, so they've been removed from the examples.