### PR TITLE
note on 100k gas limit, add getAssertionAdopter cheatcode

### DIFF
--- a/credible/assertion-patterns.mdx
+++ b/credible/assertion-patterns.mdx
@@ -3,6 +3,13 @@ title: 'Assertion Patterns'
 description: 'Common patterns and best practices for writing assertions'
 ---
 
+## Gas Consumption
+
+Assertion functions are limited to a maximum execution of 100,000 gas. If an assertion function exceeds this gas limit, the transaction will be invalidated and dropped.
+Please be aware that the gas consumption of certain cheatcodes, such as `getCallInputs`, can be variable, due to unknown lengths of the call inputs.
+We are actively working to improve this as soon as possible. Staying mindful of gas consumption is in general a good practice.
+Some of the patterns below can be used to keep gas consumption low.
+
 ## Layered Invariant Checking
 
 A common pattern in assertion writing is to first perform simple, cheap checks before moving on to more complex validations. This approach is particularly important when dealing with potential flash loan attacks or other sophisticated manipulations where values might be temporarily changed and then restored to their original state.

--- a/credible/cheatcodes.mdx
+++ b/credible/cheatcodes.mdx
@@ -27,6 +27,11 @@ experience.
 
 Loads a storage slot from an address.
 
+<Note>
+Using `forge inspect <ContractName> storage-layout` is an easy way to get the storage layout of a contract.
+This can be used to determine the storage slot of a specific variable to use in the cheatcode.
+</Note>
+
 ```solidity
 function load(
     address target, 
@@ -118,6 +123,11 @@ function bar() public {
 
 Returns state changes for a contract's storage slot within the current call stack.
 
+<Note>
+Using `forge inspect <ContractName> storage-layout` is an easy way to get the storage layout of a contract.
+This can be used to determine the storage slot of a specific variable to use in the cheatcode.
+</Note>
+
 ```solidity
 function getStateChanges(
     address contractAddress,
@@ -187,6 +197,8 @@ Call triggers execute your assertion when specific contract calls occur.
 
 ```solidity
 // Trigger on any call to the contract
+// Note: It is not recommended to use this trigger as it will trigger the assertion on every call to the contract
+// This can be expensive and inefficient
 function registerCallTrigger(
     bytes4 assertionFnSelector
 ) internal view
@@ -216,8 +228,15 @@ function triggers() external view override {
 
 Storage triggers execute your assertion when contract storage changes.
 
+<Note>
+Using `forge inspect <ContractName> storage-layout` is an easy way to get the storage layout of a contract.
+This can be used to determine the storage slot of a specific variable to use in the cheatcode.
+</Note>
+
 ```solidity
 // Trigger on ANY storage slot change
+// Note: It is not recommended to use this trigger as it will trigger the assertion on every storage slot change
+// This can be expensive and inefficient
 function registerStorageChangeTrigger(
     bytes4 assertionFnSelector
 ) internal view
@@ -271,3 +290,18 @@ function triggers() external view override {
     );
 }
 ```
+
+## Helpers
+
+### `getAssertionAdopter`
+
+Get assertion adopter contract address associated with the assertion triggering transaction.
+
+```solidity
+function getAssertionAdopter() external view returns (address);
+```
+
+This cheat code allows for not defining an assertion adopter contract in the assertion contract constructor.
+
+The cheat code is only available in the `triggers()` function and the assertion functions.
+It cannot be used in the constructor since assertion contracts have no state during deployment.

--- a/credible/pcl-assertion-guide.mdx
+++ b/credible/pcl-assertion-guide.mdx
@@ -132,6 +132,13 @@ The key principle of assertions is simple: if an assertion reverts, it means the
 If an assertion reverts, the transaction resulting in the undesired state is reverted and not included in the block.
 This results in actual hack prevention, not just mitigation.
 
+### Gas Consumption
+
+Assertion functions are limited to a maximum execution of 100,000 gas. If an assertion function exceeds this gas limit, the transaction will be invalidated and dropped.
+Please be aware that the gas consumption of certain cheatcodes, such as `getCallInputs`, can be variable, due to unknown lengths of the call inputs.
+We are actively working to improve this as soon as possible. Staying mindful of gas consumption is in general a good practice.
+See the [Assertion Patterns](/credible/assertion-patterns) for more details on ways to optimize gas consumption.
+
 ### Anatomy of the Assertion
 
 Let's break down the key components of our assertion:

--- a/credible/pcl-quickstart.mdx
+++ b/credible/pcl-quickstart.mdx
@@ -143,6 +143,10 @@ Let's create a simple assertion that checks if an `Ownable` contract's ownership
 
 For a detailed breakdown of the assertion code, see the [Assertion Guide](credible/pcl-assertion-guide).
 
+Assertion functions are limited to a maximum execution of 100,000 gas. If an assertion function exceeds this gas limit, the transaction will be invalidated and dropped.
+Please be aware that the gas consumption of certain cheatcodes, such as `getCallInputs`, can be variable, due to unknown lengths of the call inputs.
+We are actively working to improve this as soon as possible. Staying mindful of gas consumption is in general a good practice.
+
 Create a file `assertions/src/OwnableAssertion.a.sol`:
 
 ```solidity


### PR DESCRIPTION
* adds note about 100k gas limit to docs
* adds getAssertionAdopter cheatcode to the docs
* adds tip on using forge inspect to get the storage mapping of a contract
* 