### PR TITLE
Chore/update install guide monorepo

### DIFF
--- a/credible/credible-install.mdx
+++ b/credible/credible-install.mdx
@@ -26,7 +26,7 @@ Another convenient way to install `pcl` is using Cargo. It does require a couple
 - **Git**
 
 ```bash
-cargo +nightly install --git https://github.com/phylaxsystems/pcl --locked
+cargo +nightly install --git https://github.com/phylaxsystems/credible-sdk --locked pcl
 ```
 
 This will install the `pcl` binary in your Cargo installation directory (typically `~/.cargo/bin` on Unix-like systems). Make sure this directory is in your PATH.
@@ -41,13 +41,13 @@ Prerequisites:
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/phylaxsystems/pcl
+   git clone https://github.com/phylaxsystems/credible-sdk
    cd pcl
    ```
 
 2. Build the CLI:
    ```bash
-   make build
+   cargo build --release --bin pcl
    ```
 
 3. The compiled binary will be available in the `target/release` directory.

--- a/credible/pcl-quickstart.mdx
+++ b/credible/pcl-quickstart.mdx
@@ -9,8 +9,8 @@ This guide will walk you through the process of creating, testing, and submittin
 
 1. Set up your project structure
 2. Test your assertion
-3. Authenticate with `pcl`
-4. Deploy your contract
+3. Deploy your contract
+4. Authenticate with `pcl`
 5. Create a project
 6. Store your assertion
 7. Submit your assertion to the Credible Layer

--- a/docs.json
+++ b/docs.json
@@ -180,7 +180,7 @@
       },
       {
         "label": "Blog",
-        "href": "https://blog.phylax.systems"
+        "href": "https://phylax.systems/blog"
       },
       {
         "label": "Website",


### PR DESCRIPTION
Additionally fixing a couple of nits:
- Link to blog was wrong
- Ordering of steps in quickstart was wrong