### PR TITLE
feat: Update docs for Credible v2 API (Reshiram)

### DIFF
--- a/.github/workflows/import-credible-std-examples.yml
+++ b/.github/workflows/import-credible-std-examples.yml
@@ -1,4 +1,4 @@
-name: Import Assertion Examples
+name: Import Credible Std Assertion Examples
 
 on:
   # Option 1: Run when PRs are merged to main
@@ -20,7 +20,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  import-assertion-examples:
+  import-credible-std-examples:
     # For PR events, only run when merged
     if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
@@ -31,19 +31,19 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
 
-      - name: Create temporary directory and clone assertion-examples repository
+      - name: Create temporary directory and clone credible-std repository
         run: |
           # Create temporary directory
           TEMP_DIR=$(mktemp -d)
           echo "TEMP_DIR=$TEMP_DIR" >> $GITHUB_ENV
 
           # Clone into temporary directory using organization token
-          git clone --depth 1 https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/phylaxsystems/assertion-examples.git "$TEMP_DIR/assertion-examples"
+          git clone --depth 1 https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/phylaxsystems/credible-std.git "$TEMP_DIR/credible-std"
 
           echo "Directory structure:"
-          find "$TEMP_DIR/assertion-examples" -type d | sort
+          find "$TEMP_DIR/credible-std/examples/assertions-book" -type d | sort
           echo "Solidity files found:"
-          find "$TEMP_DIR/assertion-examples" -name "*.sol" | sort
+          find "$TEMP_DIR/credible-std/examples/assertions-book" -name "*.sol" | sort
 
       - name: Create directories if they don't exist
         run: mkdir -p snippets
@@ -51,7 +51,7 @@ jobs:
       - name: Copy and convert Solidity files to MDX
         run: |
           # Use the specific path to target only .sol files in assertions/src
-          ASSERTIONS_PATH="$TEMP_DIR/assertion-examples/assertions/src"
+          ASSERTIONS_PATH="$TEMP_DIR/credible-std/examples/assertions-book/assertions/src"
 
           # Check if the directory exists
           if [ ! -d "$ASSERTIONS_PATH" ]; then
@@ -77,23 +77,29 @@ jobs:
           ls -la snippets/*.mdx || echo "No MDX files generated"
 
       - name: Create Pull Request
+        if: github.event_name != 'workflow_dispatch' || inputs.dry_run == false
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GH_TOKEN }}
-          commit-message: Import assertion examples from phylaxsystems/assertion-examples
-          title: Update assertion examples
+          commit-message: Import assertion examples from phylaxsystems/credible-std
+          title: Update credible-std assertion examples
           body: |
-            This PR automatically imports assertion examples from the [phylaxsystems/assertion-examples](https://github.com/phylaxsystems/assertion-examples) repository.
+            This PR automatically imports Assertions Book examples from
+            [phylaxsystems/credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).
 
             The import was triggered by ${{ github.event_name == 'workflow_dispatch' && 'manual workflow run' || 'PR merge to main' }}.
-          branch: update-assertion-examples
+          branch: update-credible-std-examples
           delete-branch: true
           base: main
           reviewers: czepluch
 
+      - name: Show dry-run diff
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
+        run: git diff -- snippets
+
       - name: Show pull request details
-        if: steps.cpr.outputs.pull-request-operation != 'none'
+        if: steps.cpr.outputs.pull-request-operation != '' && steps.cpr.outputs.pull-request-operation != 'none'
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Each example demonstrates real-world patterns and best practices. The book also 
 
 ## Code Snippet Integration
 
-The documentation integrates code snippets from the [assertions-examples](https://github.com/phylaxsystems/assertions-examples) repository through:
+The documentation integrates Assertions Book code snippets from [`credible-std`](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book) through:
 
 1. Automated GitHub Actions
 2. Storage in `/snippets`
@@ -51,7 +51,7 @@ We welcome contributions to improve our documentation! Here are some ways you ca
 3. Make your changes:
    - Create or modify `.mdx` files in the appropriate directory
    - If adding new pages, add them to `docs.json` to include them in the navigation
-   - For code snippets, ensure they are properly referenced from the assertions-examples repo
+   - For Assertions Book code snippets, update `credible-std/examples/assertions-book/assertions/src` first, then import them into `/snippets`
 4. Test your changes:
    - Run `pnpm dev` to preview locally
    - Check for broken links using `pnpm broken-links`

--- a/README.md
+++ b/README.md
@@ -4,9 +4,18 @@ This repository contains the official documentation for Phylax's products.
 
 ## Requirements
 
-- Install `mise`
-- Install node, pnpm via `mise install`
-- Install `mintlify CLI` via `pnpm add -g mint`
+- Install Node.js 24.x
+- Enable Corepack so the repository uses the pinned pnpm version:
+
+```bash
+corepack enable
+```
+
+- Install dependencies:
+
+```bash
+pnpm install
+```
 
 ## Documentation Structure
 
@@ -44,8 +53,8 @@ We welcome contributions to improve our documentation! Here are some ways you ca
    - If adding new pages, add them to `docs.json` to include them in the navigation
    - For code snippets, ensure they are properly referenced from the assertions-examples repo
 4. Test your changes:
-   - Run `mint dev` to preview locally
-   - Check for broken links using `mint check-links`
+   - Run `pnpm dev` to preview locally
+   - Check for broken links using `pnpm broken-links`
 5. Commit your changes with a clear commit message
 6. Push to your fork and create a pull request
 

--- a/assertions-book/assertions-book-intro.mdx
+++ b/assertions-book/assertions-book-intro.mdx
@@ -12,7 +12,7 @@ Use this section when you want examples and inspiration. If you want a guided pa
 
 Each entry shows code snippets of assertions accompanied by minimal interfaces for the protocols they protect.
 
-Full examples that include mock protocol code and test cases are available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).
+Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).
 
 ## How to Use This Book
 

--- a/assertions-book/assertions-book-intro.mdx
+++ b/assertions-book/assertions-book-intro.mdx
@@ -12,7 +12,7 @@ Use this section when you want examples and inspiration. If you want a guided pa
 
 Each entry shows code snippets of assertions accompanied by minimal interfaces for the protocols they protect.
 
-Full examples that include mock protocol code and test cases are available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples).
+Full examples that include mock protocol code and test cases are available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).
 
 ## How to Use This Book
 

--- a/assertions-book/assertions/aave-v3-suite.mdx
+++ b/assertions-book/assertions/aave-v3-suite.mdx
@@ -49,7 +49,7 @@ The bug can be found in the [BorrowLogic.sol](https://github.com/phylaxsystems/a
 These assertions provide unique value beyond pure Solidity capabilities:
 
 - **Cross-transaction validation**: Verify invariants across multiple operations
-- **Oracle security**: Detect price manipulation and consistency issues
+- **Price consistency**: Detect manipulated or inconsistent pricing inputs
 - **Complex state relationships**: Validate accounting integrity
 - **Proxy/delegatecall resilience**: Use event logs for robust verification
 
@@ -75,12 +75,12 @@ These demonstrate assertion capabilities but could be implemented in Solidity:
   - Virtual balance sanity checks
   - Liquidity index integrity verification
 
-#### Oracle Security
+#### Price Consistency
 
-- **[OracleAssertions](https://github.com/phylaxsystems/aave-v3-origin/tree/main/assertions/src/production/OracleAssertions.a.sol)** - Price manipulation detection:
+- **[OracleAssertions](https://github.com/phylaxsystems/aave-v3-origin/tree/main/assertions/src/production/OracleAssertions.a.sol)** - Price consistency checks:
   - Borrow/supply/liquidation price deviation monitoring (5% max)
   - Price consistency validation across transactions
-  - Oracle manipulation attack prevention
+  - Manipulated pricing input detection
 
 #### Flashloan Protection
 

--- a/assertions-book/assertions/ass01-impl-addr-change.mdx
+++ b/assertions-book/assertions/ass01-impl-addr-change.mdx
@@ -27,7 +27,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass1ImplAddrChange />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [Owner Change](/assertions-book/assertions/ass05-ownership-change)

--- a/assertions-book/assertions/ass01-impl-addr-change.mdx
+++ b/assertions-book/assertions/ass01-impl-addr-change.mdx
@@ -27,7 +27,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass1ImplAddrChange />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [Owner Change](/assertions-book/assertions/ass05-ownership-change)

--- a/assertions-book/assertions/ass01-impl-addr-change.mdx
+++ b/assertions-book/assertions/ass01-impl-addr-change.mdx
@@ -15,7 +15,7 @@ For example, it's possible to define a whitelist of allowed implementations - an
 
 Monitors changes to the implementation address storage slot in proxy contracts using:
 
-- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Compare implementation address before and after transaction
+- `_preTx()` / `_postTx()` with Reshiram snapshot reads: Compare implementation address before and after transaction
 - `ph.loadStateAt()`: Load the implementation slot at each snapshot
 - `registerTxEndTrigger()`: Trigger when implementation address changes
 

--- a/assertions-book/assertions/ass01-impl-addr-change.mdx
+++ b/assertions-book/assertions/ass01-impl-addr-change.mdx
@@ -16,10 +16,10 @@ For example, it's possible to define a whitelist of allowed implementations - an
 Monitors changes to the implementation address storage slot in proxy contracts using:
 
 - `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Compare implementation address before and after transaction
-- `getStateChangesAddress()`: Track all changes to the implementation slot during transaction execution  
+- `ph.loadStateAt()`: Load the implementation slot at each snapshot
 - `registerTxEndTrigger()`: Trigger when implementation address changes
 
-The assertion performs both direct pre/post comparison and verification of all intermediate state changes to detect unauthorized modifications.
+The assertion performs a direct pre/post comparison of the protected implementation slot.
 
 For more information about cheatcodes, see the [Cheatcodes Documentation](/credible/cheatcodes-reference).
 

--- a/assertions-book/assertions/ass01-impl-addr-change.mdx
+++ b/assertions-book/assertions/ass01-impl-addr-change.mdx
@@ -15,9 +15,9 @@ For example, it's possible to define a whitelist of allowed implementations - an
 
 Monitors changes to the implementation address storage slot in proxy contracts using:
 
-- `ph.forkPreTx()` / `ph.forkPostTx()`: Compare implementation address before and after transaction
+- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Compare implementation address before and after transaction
 - `getStateChangesAddress()`: Track all changes to the implementation slot during transaction execution  
-- `registerStorageChangeTrigger()`: Trigger when implementation address changes
+- `registerTxEndTrigger()`: Trigger when implementation address changes
 
 The assertion performs both direct pre/post comparison and verification of all intermediate state changes to detect unauthorized modifications.
 

--- a/assertions-book/assertions/ass04-kyc-whitelist.mdx
+++ b/assertions-book/assertions/ass04-kyc-whitelist.mdx
@@ -30,7 +30,7 @@ What you should know about this KYC assertion example:
 
 <ass4KycWhitelist />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [Owner Change](/assertions-book/assertions/ass05-ownership-change)

--- a/assertions-book/assertions/ass04-kyc-whitelist.mdx
+++ b/assertions-book/assertions/ass04-kyc-whitelist.mdx
@@ -30,7 +30,7 @@ What you should know about this KYC assertion example:
 
 <ass4KycWhitelist />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [Owner Change](/assertions-book/assertions/ass05-ownership-change)

--- a/assertions-book/assertions/ass05-ownership-change.mdx
+++ b/assertions-book/assertions/ass05-ownership-change.mdx
@@ -15,7 +15,7 @@ For example, in the [Radiant Capital hack](/assertions-book/previous-hacks/hack1
 
 Monitors changes to the owner address storage slot in contracts using:
 
-- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Compare owner address before and after transaction
+- `_preTx()` / `_postTx()` with Reshiram snapshot reads: Compare owner address before and after transaction
 - `ph.loadStateAt()`: Load the owner and admin slots at each snapshot
 - `registerTxEndTrigger()`: Trigger when owner address changes
 

--- a/assertions-book/assertions/ass05-ownership-change.mdx
+++ b/assertions-book/assertions/ass05-ownership-change.mdx
@@ -27,7 +27,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass5OwnerChange />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [Implementation Address Change](/assertions-book/assertions/ass01-impl-addr-change)

--- a/assertions-book/assertions/ass05-ownership-change.mdx
+++ b/assertions-book/assertions/ass05-ownership-change.mdx
@@ -27,7 +27,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass5OwnerChange />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [Implementation Address Change](/assertions-book/assertions/ass01-impl-addr-change)

--- a/assertions-book/assertions/ass05-ownership-change.mdx
+++ b/assertions-book/assertions/ass05-ownership-change.mdx
@@ -15,9 +15,9 @@ For example, in the [Radiant Capital hack](/assertions-book/previous-hacks/hack1
 
 Monitors changes to the owner address storage slot in contracts using:
 
-- `ph.forkPreTx()` / `ph.forkPostTx()`: Compare owner address before and after transaction
+- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Compare owner address before and after transaction
 - `getStateChangesAddress()`: Track all changes to the owner address slot during transaction execution
-- `registerStorageChangeTrigger()`: Trigger when owner address changes
+- `registerTxEndTrigger()`: Trigger when owner address changes
 
 The assertion performs both direct pre/post comparison and verification of all intermediate state changes to detect unauthorized ownership modifications.
 

--- a/assertions-book/assertions/ass05-ownership-change.mdx
+++ b/assertions-book/assertions/ass05-ownership-change.mdx
@@ -16,7 +16,7 @@ For example, in the [Radiant Capital hack](/assertions-book/previous-hacks/hack1
 Monitors changes to the owner address storage slot in contracts using:
 
 - `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Compare owner address before and after transaction
-- `getStateChangesAddress()`: Track all changes to the owner address slot during transaction execution
+- `ph.loadStateAt()`: Load the owner and admin slots at each snapshot
 - `registerTxEndTrigger()`: Trigger when owner address changes
 
 The assertion performs both direct pre/post comparison and verification of all intermediate state changes to detect unauthorized ownership modifications.

--- a/assertions-book/assertions/ass06-constant-product.mdx
+++ b/assertions-book/assertions/ass06-constant-product.mdx
@@ -27,7 +27,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass6ConstantProduct />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [Fee Calculations](/assertions-book/assertions/ass14-fee-calculations)

--- a/assertions-book/assertions/ass06-constant-product.mdx
+++ b/assertions-book/assertions/ass06-constant-product.mdx
@@ -15,7 +15,7 @@ The constant product formula is fundamental to many AMM designs - any deviation 
 
 Monitors the product of reserves (k) in AMM pools to ensure it remains constant after transactions using:
 
-- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Compare reserve product before and after transaction
+- `_preTx()` / `_postTx()` with Reshiram snapshot reads: Compare reserve product before and after transaction
 - `ph.loadStateAt()`: Load reserve slots before and after the transaction
 - Direct validation that k = reserve0 * reserve1 remains unchanged
 

--- a/assertions-book/assertions/ass06-constant-product.mdx
+++ b/assertions-book/assertions/ass06-constant-product.mdx
@@ -15,7 +15,7 @@ The constant product formula is fundamental to many AMM designs - any deviation 
 
 Monitors the product of reserves (k) in AMM pools to ensure it remains constant after transactions using:
 
-- `forkPreTx()` / `forkPostTx()`: Compare reserve product before and after transaction
+- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Compare reserve product before and after transaction
 - `getStateChanges()`: Monitor reserve changes throughout transaction callstack
 - Direct validation that k = reserve0 * reserve1 remains unchanged
 

--- a/assertions-book/assertions/ass06-constant-product.mdx
+++ b/assertions-book/assertions/ass06-constant-product.mdx
@@ -27,7 +27,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass6ConstantProduct />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [Fee Calculations](/assertions-book/assertions/ass14-fee-calculations)

--- a/assertions-book/assertions/ass06-constant-product.mdx
+++ b/assertions-book/assertions/ass06-constant-product.mdx
@@ -16,7 +16,7 @@ The constant product formula is fundamental to many AMM designs - any deviation 
 Monitors the product of reserves (k) in AMM pools to ensure it remains constant after transactions using:
 
 - `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Compare reserve product before and after transaction
-- `getStateChanges()`: Monitor reserve changes throughout transaction callstack
+- `ph.loadStateAt()`: Load reserve slots before and after the transaction
 - Direct validation that k = reserve0 * reserve1 remains unchanged
 
 The assertion verifies both initial/final states and detects potential manipulations during transaction execution.
@@ -31,6 +31,6 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 ## Related Patterns
 - [Fee Calculations](/assertions-book/assertions/ass14-fee-calculations)
-- [ERC20 Drain](/assertions-book/assertions/ass20-erc20-drain)
+- [ERC20 Cumulative Outflow Breaker](/assertions-book/assertions/ass20-erc20-drain)
 - [Panic State Validation](/assertions-book/assertions/ass17-panic-state-validation)
-- [Intra Transaction Oracle Deviation](/assertions-book/assertions/ass28-intra-tx-oracle-deviation)
+- [ERC20 Cumulative Inflow Breaker](/assertions-book/assertions/ass22-erc20-inflow-breaker)

--- a/assertions-book/assertions/ass07-lending-health-factor.mdx
+++ b/assertions-book/assertions/ass07-lending-health-factor.mdx
@@ -17,7 +17,7 @@ Monitors health factors of positions during specific lending operations using:
 
 - `getCallInputs()`: Track all function calls to specified protocol functions
 - `registerFnCallTrigger()`: Trigger on lending operations (supply, borrow, withdraw, repay)
-- `PhEvm.ForkId({forkType: 1, callIndex: 0})`: Verify health factor after each operation (used by default if no pre-state specified)
+- `_postTx()`: Verify health factor after each operation (used by default if no pre-state specified)
 
 The assertion checks each lending operation individually to ensure positions affected by these operations remain healthy.
 

--- a/assertions-book/assertions/ass07-lending-health-factor.mdx
+++ b/assertions-book/assertions/ass07-lending-health-factor.mdx
@@ -38,6 +38,6 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 ## Related Patterns
 - [Full Aave Assertion Suite](/assertions-book/assertions/aave-v3-suite)
-- [ERC20 Drain](/assertions-book/assertions/ass20-erc20-drain)
+- [ERC20 Cumulative Outflow Breaker](/assertions-book/assertions/ass20-erc20-drain)
 - [Panic State Validation](/assertions-book/assertions/ass17-panic-state-validation)
 - [Owner Change](/assertions-book/assertions/ass05-ownership-change)

--- a/assertions-book/assertions/ass07-lending-health-factor.mdx
+++ b/assertions-book/assertions/ass07-lending-health-factor.mdx
@@ -27,7 +27,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass07LendingHealthFactor/>
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 <Info>
 **Extending Assertions:** When new functions are added to the protocol that should maintain healthy positions, you can create a new assertion file (e.g., `LendingHealthFactorExtendedAssertion.sol`) that follows the same pattern. This allows you to:

--- a/assertions-book/assertions/ass07-lending-health-factor.mdx
+++ b/assertions-book/assertions/ass07-lending-health-factor.mdx
@@ -27,7 +27,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass07LendingHealthFactor/>
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 <Info>
 **Extending Assertions:** When new functions are added to the protocol that should maintain healthy positions, you can create a new assertion file (e.g., `LendingHealthFactorExtendedAssertion.sol`) that follows the same pattern. This allows you to:

--- a/assertions-book/assertions/ass07-lending-health-factor.mdx
+++ b/assertions-book/assertions/ass07-lending-health-factor.mdx
@@ -16,8 +16,8 @@ Focuses on core lending operations (supply, borrow, withdraw, repay) while allow
 Monitors health factors of positions during specific lending operations using:
 
 - `getCallInputs()`: Track all function calls to specified protocol functions
-- `registerCallTrigger()`: Trigger on lending operations (supply, borrow, withdraw, repay)
-- `forkPostTx()`: Verify health factor after each operation (used by default if no pre-state specified)
+- `registerFnCallTrigger()`: Trigger on lending operations (supply, borrow, withdraw, repay)
+- `PhEvm.ForkId({forkType: 1, callIndex: 0})`: Verify health factor after each operation (used by default if no pre-state specified)
 
 The assertion checks each lending operation individually to ensure positions affected by these operations remain healthy.
 

--- a/assertions-book/assertions/ass08-sum-of-all-positions.mdx
+++ b/assertions-book/assertions/ass08-sum-of-all-positions.mdx
@@ -33,7 +33,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass8PositionsSum />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [Lending Health Factor](/assertions-book/assertions/ass07-lending-health-factor): Ensures user balances are consistent across different views

--- a/assertions-book/assertions/ass08-sum-of-all-positions.mdx
+++ b/assertions-book/assertions/ass08-sum-of-all-positions.mdx
@@ -22,7 +22,7 @@ Since direct iteration over all positions isn't currently supported, this assert
 
 Uses these cheatcodes:
 - `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture total supply before and after transaction
-- `ph.getCallInputs()`: Track function calls that modify positions
+- `ph.context()` and `ph.callinputAt()`: Inspect the triggered position-modifying call
 - `registerFnCallTrigger()`: Trigger on position-modifying functions
 
 Check the [Modified Keys](/credible/use-case-mappings/unsupported-use-cases/modified-keys) use case for details on what direct position iteration would look like.

--- a/assertions-book/assertions/ass08-sum-of-all-positions.mdx
+++ b/assertions-book/assertions/ass08-sum-of-all-positions.mdx
@@ -33,7 +33,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass8PositionsSum />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [Lending Health Factor](/assertions-book/assertions/ass07-lending-health-factor): Ensures user balances are consistent across different views

--- a/assertions-book/assertions/ass08-sum-of-all-positions.mdx
+++ b/assertions-book/assertions/ass08-sum-of-all-positions.mdx
@@ -21,7 +21,7 @@ Since direct iteration over all positions isn't currently supported, this assert
 4. Verify that the new total supply equals the pre-state total supply plus the sum of position changes
 
 Uses these cheatcodes:
-- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture total supply before and after transaction
+- `_preTx()` / `_postTx()` with Reshiram snapshot reads: Capture total supply before and after transaction
 - `ph.context()` and `ph.callinputAt()`: Inspect the triggered position-modifying call
 - `registerFnCallTrigger()`: Trigger on position-modifying functions
 

--- a/assertions-book/assertions/ass08-sum-of-all-positions.mdx
+++ b/assertions-book/assertions/ass08-sum-of-all-positions.mdx
@@ -21,9 +21,9 @@ Since direct iteration over all positions isn't currently supported, this assert
 4. Verify that the new total supply equals the pre-state total supply plus the sum of position changes
 
 Uses these cheatcodes:
-- `ph.forkPreTx()` / `ph.forkPostTx()`: Capture total supply before and after transaction
+- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture total supply before and after transaction
 - `ph.getCallInputs()`: Track function calls that modify positions
-- `registerCallTrigger()`: Trigger on position-modifying functions
+- `registerFnCallTrigger()`: Trigger on position-modifying functions
 
 Check the [Modified Keys](/credible/use-case-mappings/unsupported-use-cases/modified-keys) use case for details on what direct position iteration would look like.
 

--- a/assertions-book/assertions/ass09-timelock-verification.mdx
+++ b/assertions-book/assertions/ass09-timelock-verification.mdx
@@ -15,7 +15,7 @@ Timelocks provide a buffer against malicious governance actions - without proper
 
 Verifies timelock integrity by comparing timelock state and parameters before and after transactions:
 
-- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Compare timelock state before and after transaction
+- `_preTx()` / `_postTx()` with Reshiram snapshot reads: Compare timelock state before and after transaction
 - `registerTxEndTrigger()`: Monitor changes to timelock storage slot
 - Ensures timelock delay is within acceptable bounds (1 day to 2 weeks)
 - Confirms timelock activation follows proper procedures

--- a/assertions-book/assertions/ass09-timelock-verification.mdx
+++ b/assertions-book/assertions/ass09-timelock-verification.mdx
@@ -15,8 +15,8 @@ Timelocks provide a buffer against malicious governance actions - without proper
 
 Verifies timelock integrity by comparing timelock state and parameters before and after transactions:
 
-- `forkPreTx()` / `forkPostTx()`: Compare timelock state before and after transaction
-- `registerStorageChangeTrigger()`: Monitor changes to timelock storage slot
+- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Compare timelock state before and after transaction
+- `registerTxEndTrigger()`: Monitor changes to timelock storage slot
 - Ensures timelock delay is within acceptable bounds (1 day to 2 weeks)
 - Confirms timelock activation follows proper procedures
 

--- a/assertions-book/assertions/ass09-timelock-verification.mdx
+++ b/assertions-book/assertions/ass09-timelock-verification.mdx
@@ -28,7 +28,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass9TimelockVerification />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [Owner Change](/assertions-book/assertions/ass05-ownership-change)

--- a/assertions-book/assertions/ass09-timelock-verification.mdx
+++ b/assertions-book/assertions/ass09-timelock-verification.mdx
@@ -28,7 +28,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass9TimelockVerification />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [Owner Change](/assertions-book/assertions/ass05-ownership-change)

--- a/assertions-book/assertions/ass10-oracle-validation.mdx
+++ b/assertions-book/assertions/ass10-oracle-validation.mdx
@@ -18,8 +18,8 @@ Stale oracle data can indicate service disruption or attacks on oracle infrastru
 
 Monitors oracle timestamp updates when critical protocol functions are called:
 
-- `forkPostTx()`: Check oracle's last update time after transaction
-- `registerCallTrigger()`: Trigger on functions that rely on oracle data (e.g., DEX swaps)
+- `PhEvm.ForkId({forkType: 1, callIndex: 0})`: Check oracle's last update time after transaction
+- `registerFnCallTrigger()`: Trigger on functions that rely on oracle data (e.g., DEX swaps)
 - Verify oracle's last update time is within defined maximum time window
 
 Upon functions that rely on oracle data, the assertion ensures transactions only proceed with fresh oracle data, preventing operations with stale pricing information.

--- a/assertions-book/assertions/ass10-oracle-validation.mdx
+++ b/assertions-book/assertions/ass10-oracle-validation.mdx
@@ -18,7 +18,7 @@ Stale oracle data can indicate service disruption or attacks on oracle infrastru
 
 Monitors oracle timestamp updates when critical protocol functions are called:
 
-- `PhEvm.ForkId({forkType: 1, callIndex: 0})`: Check oracle's last update time after transaction
+- `_postTx()`: Check oracle's last update time after transaction
 - `registerFnCallTrigger()`: Trigger on functions that rely on oracle data (e.g., DEX swaps)
 - Verify oracle's last update time is within defined maximum time window
 

--- a/assertions-book/assertions/ass10-oracle-validation.mdx
+++ b/assertions-book/assertions/ass10-oracle-validation.mdx
@@ -30,7 +30,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass10OracleLiveness />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [Oracle Price Deviation](/assertions-book/assertions/ass28-intra-tx-oracle-deviation)

--- a/assertions-book/assertions/ass10-oracle-validation.mdx
+++ b/assertions-book/assertions/ass10-oracle-validation.mdx
@@ -30,7 +30,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass10OracleLiveness />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [Oracle Price Deviation](/assertions-book/assertions/ass28-intra-tx-oracle-deviation)

--- a/assertions-book/assertions/ass11-twap-deviation.mdx
+++ b/assertions-book/assertions/ass11-twap-deviation.mdx
@@ -15,7 +15,7 @@ Sudden price deviations could indicate manipulation through flash loan attacks o
 
 Monitors TWAP price changes using a two-stage approach to ensure price stability:
 
-- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Compare post-transaction price against pre-transaction TWAP
+- `_preTx()` / `_postTx()` with Reshiram snapshot reads: Compare post-transaction price against pre-transaction TWAP
 - `getStateChangesUint()`: Track all price changes during transaction execution
 - `registerTxEndTrigger()`: Trigger when price storage slot changes
 

--- a/assertions-book/assertions/ass11-twap-deviation.mdx
+++ b/assertions-book/assertions/ass11-twap-deviation.mdx
@@ -27,7 +27,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass11TwapDeviation />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [Intra-tx Oracle Deviation](/assertions-book/assertions/ass28-intra-tx-oracle-deviation)

--- a/assertions-book/assertions/ass11-twap-deviation.mdx
+++ b/assertions-book/assertions/ass11-twap-deviation.mdx
@@ -15,9 +15,9 @@ Sudden price deviations could indicate manipulation through flash loan attacks o
 
 Monitors TWAP price changes using a two-stage approach to ensure price stability:
 
-- `ph.forkPreTx()` / `ph.forkPostTx()`: Compare post-transaction price against pre-transaction TWAP
+- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Compare post-transaction price against pre-transaction TWAP
 - `getStateChangesUint()`: Track all price changes during transaction execution
-- `registerStorageChangeTrigger()`: Trigger when price storage slot changes
+- `registerTxEndTrigger()`: Trigger when price storage slot changes
 
 The assertion verifies both the final price and any intermediate price updates against the initial TWAP to detect flash loan attacks and price manipulation throughout the transaction.
 

--- a/assertions-book/assertions/ass11-twap-deviation.mdx
+++ b/assertions-book/assertions/ass11-twap-deviation.mdx
@@ -27,7 +27,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass11TwapDeviation />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [Intra-tx Oracle Deviation](/assertions-book/assertions/ass28-intra-tx-oracle-deviation)

--- a/assertions-book/assertions/ass12-erc4626-assets-to-shares.mdx
+++ b/assertions-book/assertions/ass12-erc4626-assets-to-shares.mdx
@@ -27,8 +27,8 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass12Erc4626AssetsShares />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 
-- [ERC4626 Vault Operations](/assertions-book/assertions/ass13-erc4626-deposit-withdraw) — deposit, withdraw, mint, redeem with batch handling
+- [ERC4626 Deposit and Withdraw Share Price](./ass13-erc4626-deposit-withdraw): deposit and withdraw share-price checks

--- a/assertions-book/assertions/ass12-erc4626-assets-to-shares.mdx
+++ b/assertions-book/assertions/ass12-erc4626-assets-to-shares.mdx
@@ -27,7 +27,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass12Erc4626AssetsShares />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 

--- a/assertions-book/assertions/ass12-erc4626-assets-to-shares.mdx
+++ b/assertions-book/assertions/ass12-erc4626-assets-to-shares.mdx
@@ -15,7 +15,7 @@ Any violation could allow unauthorized share minting that dilutes existing holde
 
 Verifies the fundamental ERC4626 share-to-asset relationship using a basic approach:
 
-- `registerStorageChangeTrigger()`: Trigger when total supply storage slot changes
+- `registerTxEndTrigger()`: Trigger when total supply storage slot changes
 - Verify total assets are sufficient to back all outstanding shares
 - Ensure share value is preserved and users can withdraw their assets
 

--- a/assertions-book/assertions/ass13-erc4626-deposit-withdraw.mdx
+++ b/assertions-book/assertions/ass13-erc4626-deposit-withdraw.mdx
@@ -23,7 +23,7 @@ Checks ERC4626 share-price safety around deposit and withdraw calls:
 
 <ass13Erc4626DepositWithdraw />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 

--- a/assertions-book/assertions/ass13-erc4626-deposit-withdraw.mdx
+++ b/assertions-book/assertions/ass13-erc4626-deposit-withdraw.mdx
@@ -4,7 +4,6 @@ description: Ensure that ERC4626 operations maintain correct accounting
 ---
 
 import ass13Erc4626DepositWithdraw from "/snippets/ass13-erc4626-deposit-withdraw.a.mdx";
-import ass2Erc4626Operations from "/snippets/ass2-erc4626-operations.a.mdx";
 
 ## When to Use This Pattern
 
@@ -12,42 +11,17 @@ Ensures ERC4626 operations maintain correct accounting for both assets and share
 
 Any discrepancy between preview functions and actual operations could lead to users receiving incorrect amounts, potentially resulting in value loss.
 
-## Pattern Variant 1: Deposit and Withdraw
+## What This Pattern Checks
 
-Five assertion functions for deposit/withdrawal verification:
+Checks ERC4626 share-price safety around deposit and withdraw calls:
 
-**Deposit Assertions:**
-- **Asset Accounting**: Total vault assets increase by exact deposit amount
-- **Share Accounting**: Depositors receive correct shares
-
-**Withdrawal Assertions:**
-- **Asset Accounting**: Total vault assets decrease by exact withdrawal amount  
-- **Share Accounting**: Correct shares burned
-
-**Share Value Assertion:**
-- **Share Value Monotonicity**: Share value never decreases unexpectedly (with precision tolerance for rounding)
-
-Uses `ph.getCallInputs()`, `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads, and `registerFnCallTrigger()`. See the [Cheatcodes Reference](/credible/cheatcodes-reference) for details.
+- `registerAssertionSpec(AssertionSpec.Reshiram)`: Registers the assertion as a Reshiram assertion.
+- `registerFnCallTrigger()`: Runs the assertion around `deposit` and `withdraw` calls.
+- `ph.context()`: Reads the current call frame.
+- `PhEvm.ForkId({forkType: 2, callIndex: ctx.callStart})` / `PhEvm.ForkId({forkType: 3, callIndex: ctx.callEnd})`: Reads pre-call and post-call snapshots.
+- `ph.loadStateAt()`: Loads total assets and total supply at each snapshot.
 
 <ass13Erc4626DepositWithdraw />
-
-## Pattern Variant 2: Full ERC4626 Operation Coverage
-
-Use this approach when your protocol:
-- Uses mint/redeem in addition to deposit/withdraw
-- Handles multiple operations in a single transaction
-- Needs validation against preview functions
-
-Four assertion functions covering all ERC4626 operations:
-
-- **Batch Operations Consistency**: Validates deposit, mint, withdraw, and redeem in a single transaction. Uses preview functions for expected value calculation.
-- **Deposit Balance Verification**: Confirms vault assets increase by exact deposit amount
-- **Depositor Shares Verification**: Confirms depositor receives shares matching `previewDeposit()`
-- **Base Invariant**: Ensures vault always has at least as many assets as shares
-
-Uses both `registerFnCallTrigger()` and `registerTxEndTrigger()`.
-
-<ass2Erc4626Operations />
 
 <Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
 

--- a/assertions-book/assertions/ass13-erc4626-deposit-withdraw.mdx
+++ b/assertions-book/assertions/ass13-erc4626-deposit-withdraw.mdx
@@ -27,7 +27,7 @@ Five assertion functions for deposit/withdrawal verification:
 **Share Value Assertion:**
 - **Share Value Monotonicity**: Share value never decreases unexpectedly (with precision tolerance for rounding)
 
-Uses `ph.getCallInputs()`, `ph.forkPreTx()` / `ph.forkPostTx()`, and `registerCallTrigger()`. See the [Cheatcodes Reference](/credible/cheatcodes-reference) for details.
+Uses `ph.getCallInputs()`, `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads, and `registerFnCallTrigger()`. See the [Cheatcodes Reference](/credible/cheatcodes-reference) for details.
 
 <ass13Erc4626DepositWithdraw />
 
@@ -45,7 +45,7 @@ Four assertion functions covering all ERC4626 operations:
 - **Depositor Shares Verification**: Confirms depositor receives shares matching `previewDeposit()`
 - **Base Invariant**: Ensures vault always has at least as many assets as shares
 
-Uses both `registerCallTrigger()` and `registerStorageChangeTrigger()`.
+Uses both `registerFnCallTrigger()` and `registerTxEndTrigger()`.
 
 <ass2Erc4626Operations />
 

--- a/assertions-book/assertions/ass13-erc4626-deposit-withdraw.mdx
+++ b/assertions-book/assertions/ass13-erc4626-deposit-withdraw.mdx
@@ -1,15 +1,15 @@
 ---
-title: ERC4626 Vault Operations
-description: Ensure that ERC4626 operations maintain correct accounting
+title: ERC4626 Deposit and Withdraw Share Price
+description: Reference pattern for checking ERC4626 deposit and withdraw calls against share-price dilution
 ---
 
 import ass13Erc4626DepositWithdraw from "/snippets/ass13-erc4626-deposit-withdraw.a.mdx";
 
 ## When to Use This Pattern
 
-Ensures ERC4626 operations maintain correct accounting for both assets and shares, preventing share calculation errors and fund loss. Critical for yield aggregators (Yearn, Aave, Compound), lending protocols with ERC4626 interest-bearing tokens, liquidity pools using ERC4626 for LP tokens, and staking protocols with ERC4626 staking tokens.
+Use this pattern when ERC4626 deposit or withdraw calls must not dilute existing or remaining shares. It applies to yield aggregators, lending protocols with ERC4626 interest-bearing tokens, liquidity pools using ERC4626 shares, and staking protocols with ERC4626 receipt tokens.
 
-Any discrepancy between preview functions and actual operations could lead to users receiving incorrect amounts, potentially resulting in value loss.
+This pattern checks share-price monotonicity around matched deposit and withdraw calls. It does not cover mint/redeem entry points or batch-wide preview-function validation.
 
 ## What This Pattern Checks
 
@@ -21,11 +21,13 @@ Checks ERC4626 share-price safety around deposit and withdraw calls:
 - `PhEvm.ForkId({forkType: 2, callIndex: ctx.callStart})` / `PhEvm.ForkId({forkType: 3, callIndex: ctx.callEnd})`: Reads pre-call and post-call snapshots.
 - `ph.loadStateAt()`: Loads total assets and total supply at each snapshot.
 
+## Assertion Pattern
+
 <ass13Erc4626DepositWithdraw />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 
-- [ERC4626 Assets to Shares](/assertions-book/assertions/ass12-erc4626-assets-to-shares) — simple base invariant check
-- [Harvest Increases Balance](/assertions-book/assertions/ass18-harvest-increases-balance) — yield operation validation
+- [ERC4626 Assets to Shares](./ass12-erc4626-assets-to-shares): simple base invariant check
+- [Harvest Increases Balance](./ass18-harvest-increases-balance): yield operation validation

--- a/assertions-book/assertions/ass14-fee-calculations.mdx
+++ b/assertions-book/assertions/ass14-fee-calculations.mdx
@@ -27,7 +27,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass14FeeVerification />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [Price Within Ticks](/assertions-book/assertions/ass15-price-within-ticks)

--- a/assertions-book/assertions/ass14-fee-calculations.mdx
+++ b/assertions-book/assertions/ass14-fee-calculations.mdx
@@ -15,8 +15,8 @@ Unexpected fee changes can lead to unauthorized manipulation, protocol revenue l
 
 Uses a whitelist approach to control fee changes:
 
-- `registerStorageChangeTrigger()`: Detect changes to fee storage slot
-- `ph.load()`: Retrieve new fee value after change
+- `registerTxEndTrigger()`: Detect changes to fee storage slot
+- `ph.loadStateAt()`: Retrieve new fee value after change
 - `getStateChangesUint()`: Verify all state changes for fee storage slot
 - Maintains hardcoded allowed fee values for stable pools (0.1%, 0.15%) and non-stable pools (0.25%, 0.30%)
 

--- a/assertions-book/assertions/ass14-fee-calculations.mdx
+++ b/assertions-book/assertions/ass14-fee-calculations.mdx
@@ -17,7 +17,6 @@ Uses a whitelist approach to control fee changes:
 
 - `registerTxEndTrigger()`: Detect changes to fee storage slot
 - `ph.loadStateAt()`: Retrieve new fee value after change
-- `getStateChangesUint()`: Verify all state changes for fee storage slot
 - Maintains hardcoded allowed fee values for stable pools (0.1%, 0.15%) and non-stable pools (0.25%, 0.30%)
 
 When triggered, verifies the new fee matches one of the allowed values, preventing unauthorized modifications while allowing proper protocol updates.

--- a/assertions-book/assertions/ass14-fee-calculations.mdx
+++ b/assertions-book/assertions/ass14-fee-calculations.mdx
@@ -27,7 +27,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass14FeeVerification />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [Price Within Ticks](/assertions-book/assertions/ass15-price-within-ticks)

--- a/assertions-book/assertions/ass15-price-within-ticks.mdx
+++ b/assertions-book/assertions/ass15-price-within-ticks.mdx
@@ -28,7 +28,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass15PriceWithinTicks />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [Fee Calculations](/assertions-book/assertions/ass14-fee-calculations)

--- a/assertions-book/assertions/ass15-price-within-ticks.mdx
+++ b/assertions-book/assertions/ass15-price-within-ticks.mdx
@@ -15,7 +15,7 @@ If attackers could push prices outside valid tick ranges, they could execute tra
 
 Implements focused tick integrity verification:
 
-- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture tick state before and after transaction
+- `_preTx()` / `_postTx()` with Reshiram snapshot reads: Capture tick state before and after transaction
 - `registerTxEndTrigger()`: Monitor changes to tick-related storage slots
 - Verify ticks stay within global bounds (-887272 to 887272)
 - Ensure ticks align with pool's tick spacing requirements

--- a/assertions-book/assertions/ass15-price-within-ticks.mdx
+++ b/assertions-book/assertions/ass15-price-within-ticks.mdx
@@ -15,8 +15,8 @@ If attackers could push prices outside valid tick ranges, they could execute tra
 
 Implements focused tick integrity verification:
 
-- `ph.forkPreTx()` / `ph.forkPostTx()`: Capture tick state before and after transaction
-- `registerStorageChangeTrigger()`: Monitor changes to tick-related storage slots
+- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture tick state before and after transaction
+- `registerTxEndTrigger()`: Monitor changes to tick-related storage slots
 - Verify ticks stay within global bounds (-887272 to 887272)
 - Ensure ticks align with pool's tick spacing requirements
 

--- a/assertions-book/assertions/ass15-price-within-ticks.mdx
+++ b/assertions-book/assertions/ass15-price-within-ticks.mdx
@@ -28,7 +28,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass15PriceWithinTicks />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [Fee Calculations](/assertions-book/assertions/ass14-fee-calculations)

--- a/assertions-book/assertions/ass16-liquidation-health-factor.mdx
+++ b/assertions-book/assertions/ass16-liquidation-health-factor.mdx
@@ -28,7 +28,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass16LiquidationHealthFactor />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [ERC4626 Assets to Shares](/assertions-book/assertions/ass12-erc4626-assets-to-shares)

--- a/assertions-book/assertions/ass16-liquidation-health-factor.mdx
+++ b/assertions-book/assertions/ass16-liquidation-health-factor.mdx
@@ -28,7 +28,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass16LiquidationHealthFactor />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [ERC4626 Assets to Shares](/assertions-book/assertions/ass12-erc4626-assets-to-shares)

--- a/assertions-book/assertions/ass16-liquidation-health-factor.mdx
+++ b/assertions-book/assertions/ass16-liquidation-health-factor.mdx
@@ -15,10 +15,10 @@ Incorrect health factor validation could lead to unfair liquidations, protocol i
 
 Implements multi-layered liquidation health factor verification:
 
-- **Pre-liquidation**: `forkPreTx()` captures health factor before liquidation, verifies position is actually unhealthy
-- **Post-liquidation**: `forkPostTx()` verifies health factor improves after liquidation
+- **Pre-liquidation**: `PhEvm.ForkId({forkType: 0, callIndex: 0})` captures health factor before liquidation, verifies position is actually unhealthy
+- **Post-liquidation**: `PhEvm.ForkId({forkType: 1, callIndex: 0})` verifies health factor improves after liquidation
 - **Parameter validation**: `getCallInputs()` monitors liquidation calls, validates seized assets and repaid shares are non-zero, enforces maximum liquidation amounts
-- `registerCallTrigger()`: Triggers on liquidation function calls
+- `registerFnCallTrigger()`: Triggers on liquidation function calls
 
 The assertion ensures only unhealthy positions can be liquidated, liquidations improve position health, and liquidation amounts remain within safe limits for proper protocol risk management.
 

--- a/assertions-book/assertions/ass16-liquidation-health-factor.mdx
+++ b/assertions-book/assertions/ass16-liquidation-health-factor.mdx
@@ -15,8 +15,8 @@ Incorrect health factor validation could lead to unfair liquidations, protocol i
 
 Implements multi-layered liquidation health factor verification:
 
-- **Pre-liquidation**: `PhEvm.ForkId({forkType: 0, callIndex: 0})` captures health factor before liquidation, verifies position is actually unhealthy
-- **Post-liquidation**: `PhEvm.ForkId({forkType: 1, callIndex: 0})` verifies health factor improves after liquidation
+- **Pre-liquidation**: `_preTx()` captures health factor before liquidation, verifies position is actually unhealthy
+- **Post-liquidation**: `_postTx()` verifies health factor improves after liquidation
 - **Parameter validation**: `getCallInputs()` monitors liquidation calls, validates seized assets and repaid shares are non-zero, enforces maximum liquidation amounts
 - `registerFnCallTrigger()`: Triggers on liquidation function calls
 

--- a/assertions-book/assertions/ass17-panic-state-validation.mdx
+++ b/assertions-book/assertions/ass17-panic-state-validation.mdx
@@ -16,7 +16,7 @@ Improper handling of pause states can lead to fund lockups, unauthorized access,
 Monitors protocol balance and pause state to ensure proper emergency behavior using a multi-layered approach:
 
 - `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture protocol state before and after transaction
-- `getStateChangesUint()`: Track all state changes during transaction
+- `ph.loadStateAt()`: Read the pause and balance slots at pre-transaction and post-transaction snapshots
 - `registerFnCallTrigger()`: Monitor all function calls to the contract
 - Verify protocol balance can only decrease when paused (allowing withdrawals)
 - Detect unauthorized modifications during pause periods

--- a/assertions-book/assertions/ass17-panic-state-validation.mdx
+++ b/assertions-book/assertions/ass17-panic-state-validation.mdx
@@ -15,7 +15,7 @@ Improper handling of pause states can lead to fund lockups, unauthorized access,
 
 Monitors protocol balance and pause state to ensure proper emergency behavior using a multi-layered approach:
 
-- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture protocol state before and after transaction
+- `_preTx()` / `_postTx()` with Reshiram snapshot reads: Capture protocol state before and after transaction
 - `ph.loadStateAt()`: Read the pause and balance slots at pre-transaction and post-transaction snapshots
 - `registerFnCallTrigger()`: Monitor all function calls to the contract
 - Verify protocol balance can only decrease when paused (allowing withdrawals)

--- a/assertions-book/assertions/ass17-panic-state-validation.mdx
+++ b/assertions-book/assertions/ass17-panic-state-validation.mdx
@@ -31,7 +31,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass17PanicStateVerification />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [Implementation Address Change](/assertions-book/assertions/ass01-impl-addr-change)

--- a/assertions-book/assertions/ass17-panic-state-validation.mdx
+++ b/assertions-book/assertions/ass17-panic-state-validation.mdx
@@ -31,7 +31,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass17PanicStateVerification />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [Implementation Address Change](/assertions-book/assertions/ass01-impl-addr-change)

--- a/assertions-book/assertions/ass17-panic-state-validation.mdx
+++ b/assertions-book/assertions/ass17-panic-state-validation.mdx
@@ -15,9 +15,9 @@ Improper handling of pause states can lead to fund lockups, unauthorized access,
 
 Monitors protocol balance and pause state to ensure proper emergency behavior using a multi-layered approach:
 
-- `ph.forkPreTx()` / `ph.forkPostTx()`: Capture protocol state before and after transaction
+- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture protocol state before and after transaction
 - `getStateChangesUint()`: Track all state changes during transaction
-- `registerCallTrigger()`: Monitor all function calls to the contract
+- `registerFnCallTrigger()`: Monitor all function calls to the contract
 - Verify protocol balance can only decrease when paused (allowing withdrawals)
 - Detect unauthorized modifications during pause periods
 

--- a/assertions-book/assertions/ass18-harvest-increases-balance.mdx
+++ b/assertions-book/assertions/ass18-harvest-increases-balance.mdx
@@ -16,7 +16,7 @@ Incorrect harvest implementations could lead to loss of user funds, price per sh
 Implements multi-layered approach to verify harvest operations:
 
 - `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture vault balance and price per share before/after harvest
-- `getStateChangesUint()`: Monitor all balance changes during transaction execution
+- `ph.loadStateAt()`: Read balance and price-per-share slots before and after the harvest call
 - `registerFnCallTrigger()`: Trigger on harvest function calls
 - Ensures balance hasn't decreased (can stay same if harvested recently)
 - Confirms price per share hasn't decreased
@@ -34,5 +34,5 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 ## Related Patterns
 - [ERC4626 Assets to Shares](/assertions-book/assertions/ass12-erc4626-assets-to-shares)
-- [ERC20 Drain](/assertions-book/assertions/ass20-erc20-drain)
+- [ERC20 Cumulative Outflow Breaker](/assertions-book/assertions/ass20-erc20-drain)
 - [Price Within Ticks](/assertions-book/assertions/ass15-price-within-ticks)

--- a/assertions-book/assertions/ass18-harvest-increases-balance.mdx
+++ b/assertions-book/assertions/ass18-harvest-increases-balance.mdx
@@ -30,7 +30,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass18HarvestIncreasesBalance />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [ERC4626 Assets to Shares](/assertions-book/assertions/ass12-erc4626-assets-to-shares)

--- a/assertions-book/assertions/ass18-harvest-increases-balance.mdx
+++ b/assertions-book/assertions/ass18-harvest-increases-balance.mdx
@@ -15,7 +15,7 @@ Incorrect harvest implementations could lead to loss of user funds, price per sh
 
 Implements multi-layered approach to verify harvest operations:
 
-- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture vault balance and price per share before/after harvest
+- `_preTx()` / `_postTx()` with Reshiram snapshot reads: Capture vault balance and price per share before/after harvest
 - `ph.loadStateAt()`: Read balance and price-per-share slots before and after the harvest call
 - `registerFnCallTrigger()`: Trigger on harvest function calls
 - Ensures balance hasn't decreased (can stay same if harvested recently)

--- a/assertions-book/assertions/ass18-harvest-increases-balance.mdx
+++ b/assertions-book/assertions/ass18-harvest-increases-balance.mdx
@@ -15,9 +15,9 @@ Incorrect harvest implementations could lead to loss of user funds, price per sh
 
 Implements multi-layered approach to verify harvest operations:
 
-- `forkPreTx()` / `forkPostTx()`: Capture vault balance and price per share before/after harvest
+- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture vault balance and price per share before/after harvest
 - `getStateChangesUint()`: Monitor all balance changes during transaction execution
-- `registerCallTrigger()`: Trigger on harvest function calls
+- `registerFnCallTrigger()`: Trigger on harvest function calls
 - Ensures balance hasn't decreased (can stay same if harvested recently)
 - Confirms price per share hasn't decreased
 - Prevents manipulation through multiple harvest calls

--- a/assertions-book/assertions/ass18-harvest-increases-balance.mdx
+++ b/assertions-book/assertions/ass18-harvest-increases-balance.mdx
@@ -30,7 +30,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass18HarvestIncreasesBalance />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [ERC4626 Assets to Shares](/assertions-book/assertions/ass12-erc4626-assets-to-shares)

--- a/assertions-book/assertions/ass19-tokens-borrowed-invariant.mdx
+++ b/assertions-book/assertions/ass19-tokens-borrowed-invariant.mdx
@@ -15,7 +15,7 @@ Violating this invariant could lead to protocol insolvency, loss of user funds, 
 
 Implements straightforward verification that total tokens borrowed never exceed total tokens deposited:
 
-- `PhEvm.ForkId({forkType: 1, callIndex: 0})`: Capture protocol state after transaction to verify invariant holds
+- `_postTx()`: Capture protocol state after transaction to verify invariant holds
 - `registerTxEndTrigger()`: Trigger on storage slots tracking supply and borrow totals
 - Check total supply of assets (tokens deposited) and total borrowed assets
 - Assert total supply ≥ total borrowed assets

--- a/assertions-book/assertions/ass19-tokens-borrowed-invariant.mdx
+++ b/assertions-book/assertions/ass19-tokens-borrowed-invariant.mdx
@@ -28,7 +28,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass19TokensBorrowedInvariant />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [Liquidation Health Factor](/assertions-book/assertions/ass16-liquidation-health-factor)

--- a/assertions-book/assertions/ass19-tokens-borrowed-invariant.mdx
+++ b/assertions-book/assertions/ass19-tokens-borrowed-invariant.mdx
@@ -15,8 +15,8 @@ Violating this invariant could lead to protocol insolvency, loss of user funds, 
 
 Implements straightforward verification that total tokens borrowed never exceed total tokens deposited:
 
-- `ph.forkPostTx()`: Capture protocol state after transaction to verify invariant holds
-- `registerStorageChangeTrigger()`: Trigger on storage slots tracking supply and borrow totals
+- `PhEvm.ForkId({forkType: 1, callIndex: 0})`: Capture protocol state after transaction to verify invariant holds
+- `registerTxEndTrigger()`: Trigger on storage slots tracking supply and borrow totals
 - Check total supply of assets (tokens deposited) and total borrowed assets
 - Assert total supply ≥ total borrowed assets
 

--- a/assertions-book/assertions/ass19-tokens-borrowed-invariant.mdx
+++ b/assertions-book/assertions/ass19-tokens-borrowed-invariant.mdx
@@ -28,7 +28,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass19TokensBorrowedInvariant />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [Liquidation Health Factor](/assertions-book/assertions/ass16-liquidation-health-factor)

--- a/assertions-book/assertions/ass19-tokens-borrowed-invariant.mdx
+++ b/assertions-book/assertions/ass19-tokens-borrowed-invariant.mdx
@@ -32,5 +32,5 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 ## Related Patterns
 - [Liquidation Health Factor](/assertions-book/assertions/ass16-liquidation-health-factor)
-- [ERC20 Drain](/assertions-book/assertions/ass20-erc20-drain)
+- [ERC20 Cumulative Outflow Breaker](/assertions-book/assertions/ass20-erc20-drain)
 - [Lending Health Factor](/assertions-book/assertions/ass07-lending-health-factor)

--- a/assertions-book/assertions/ass20-erc20-drain.mdx
+++ b/assertions-book/assertions/ass20-erc20-drain.mdx
@@ -32,10 +32,11 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass20ERC20Drain />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 
 - [ERC20 Cumulative Inflow Breaker](/assertions-book/assertions/ass22-erc20-inflow-breaker)
+- [Ether Drain](/assertions-book/assertions/ass21-ether-drain)
 - [Ownership Change](/assertions-book/assertions/ass05-ownership-change)
 - [Implementation Address Change](/assertions-book/assertions/ass01-impl-addr-change)

--- a/assertions-book/assertions/ass20-erc20-drain.mdx
+++ b/assertions-book/assertions/ass20-erc20-drain.mdx
@@ -15,8 +15,8 @@ By limiting outflow rates, protocols gain valuable time to respond to security i
 
 Implements percentage-based limit on token outflows in a single transaction:
 
-- `forkPreTx()` / `forkPostTx()`: Capture token balance before and after transaction
-- `registerCallTrigger()`: Trigger on every transaction without specifying particular function signature
+- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture token balance before and after transaction
+- `registerFnCallTrigger()`: Trigger on every transaction without specifying particular function signature
 - Calculate percentage of tokens withdrawn in transaction
 - Revert if withdrawal percentage exceeds configured threshold
 

--- a/assertions-book/assertions/ass20-erc20-drain.mdx
+++ b/assertions-book/assertions/ass20-erc20-drain.mdx
@@ -32,7 +32,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass20ERC20Drain />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 

--- a/assertions-book/assertions/ass20-erc20-drain.mdx
+++ b/assertions-book/assertions/ass20-erc20-drain.mdx
@@ -1,29 +1,29 @@
 ---
-title: 'ERC20 Drain'
-description: 'Prevent tokens from being drained from a contract'
+title: 'ERC20 Cumulative Outflow Breaker'
+description: 'Limit cumulative ERC20 outflows with a Reshiram circuit-breaker trigger'
 ---
 
 import ass20ERC20Drain from "/snippets/ass20-erc20-drain.a.mdx";
 
 ## When to Use This Pattern
 
-Monitors and limits token outflows to prevent catastrophic asset loss during exploits, creating a delay window for emergency response. Critical for lending protocols with token reserves (Compound, Aave, Morpho), liquidity pools and DEXs, treasury management systems and DAOs, yield aggregators, and cross-chain bridges holding tokens in escrow.
+Monitors and limits cumulative token outflows to prevent catastrophic asset loss during exploits, creating a response window for protocol operators. Use it for lending reserves, vault custody, bridge escrows, treasuries, liquidity pools, and other contracts where rapid ERC20 withdrawals are a critical risk.
 
-By limiting outflow rates, protocols gain valuable time to respond to security incidents and activate circuit breakers, even if complete prevention isn't possible.
+This is a V2 Reshiram circuit-breaker pattern. The rolling-window accounting is handled by the trigger/precompile machinery, not by assertion-authored storage.
 
 ## What This Pattern Checks
 
-Implements percentage-based limit on token outflows in a single transaction:
+Registers a percentage-based cumulative outflow limit:
 
-- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture token balance before and after transaction
-- `registerFnCallTrigger()`: Trigger on every transaction without specifying particular function signature
-- Calculate percentage of tokens withdrawn in transaction
-- Revert if withdrawal percentage exceeds configured threshold
+- `registerAssertionSpec(AssertionSpec.Reshiram)`: Registers the assertion as a Reshiram assertion.
+- `watchCumulativeOutflow(token, thresholdBps, windowDuration, assertFn)`: Watches ERC20 outflow over a rolling window.
+- `ph.outflowContext()`: Reads the token context inside the triggered assertion.
+- Reverts when cumulative outflow breaches the configured threshold.
 
-The assertion ensures normal protocol operations continue unimpeded while blocking suspicious large withdrawals and maintaining token outflows within reasonable operational parameters.
+The assertion does not manually store balances or rolling counters. The Reshiram circuit-breaker trigger is responsible for tracking the window and invoking the assertion when the limit is exceeded.
 
 <Warning>
-This assertion is meant to be an example of monitoring token outflows. Due to the nature of how assertions work, only the owner of a contract can enable assertions on it. Since ERC20 tokens are contracts that track balances, but you don't physically store the tokens in your own contract, you cannot directly control balance changes in the token contract itself. This assertion would need to be implemented by the protocol contract owner to monitor their own contract's token balances.
+As of May 6, 2026, the v2 Reshiram spec is not live on Linea mainnet. Treat this pattern as a local, development, or forward-looking example until Linea mainnet supports the spec.
 </Warning>
 
 For more information about cheatcodes, see the [Cheatcodes Documentation](/credible/cheatcodes-reference).
@@ -36,6 +36,6 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 ## Related Patterns
 
-- [Ether Drain](/assertions-book/assertions/ass21-ether-drain)
+- [ERC20 Cumulative Inflow Breaker](/assertions-book/assertions/ass22-erc20-inflow-breaker)
 - [Ownership Change](/assertions-book/assertions/ass05-ownership-change)
 - [Implementation Address Change](/assertions-book/assertions/ass01-impl-addr-change)

--- a/assertions-book/assertions/ass21-ether-drain.mdx
+++ b/assertions-book/assertions/ass21-ether-drain.mdx
@@ -17,8 +17,8 @@ Malicious actors often attempt to extract all available ETH in a single transact
 
 Implements tiered protection strategy to detect rapid ETH draining:
 
-- `forkPreTx()` / `forkPostTx()`: Capture contract's ETH balance and whitelist balances before/after transaction
-- `registerBalanceChangeTrigger()`: Trigger when ETH balances change
+- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture contract's ETH balance and whitelist balances before/after transaction
+- `registerTxEndTrigger()`: Trigger when ETH balances change
 - For small withdrawals (below threshold): Allow regardless of destination
 - For large withdrawals (above threshold): Require destination to be whitelisted address
 - If no whitelist defined, block all large withdrawals as safety measure

--- a/assertions-book/assertions/ass21-ether-drain.mdx
+++ b/assertions-book/assertions/ass21-ether-drain.mdx
@@ -34,6 +34,6 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 <Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
 
 ## Related Patterns
-- [ERC20 Drain](/assertions-book/assertions/ass20-erc20-drain)
+- [ERC20 Cumulative Outflow Breaker](/assertions-book/assertions/ass20-erc20-drain)
 - [Implementation Address Change](/assertions-book/assertions/ass01-impl-addr-change)
 - [Ownership Change](/assertions-book/assertions/ass05-ownership-change)

--- a/assertions-book/assertions/ass21-ether-drain.mdx
+++ b/assertions-book/assertions/ass21-ether-drain.mdx
@@ -31,7 +31,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass21EtherDrain />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [ERC20 Cumulative Outflow Breaker](/assertions-book/assertions/ass20-erc20-drain)

--- a/assertions-book/assertions/ass21-ether-drain.mdx
+++ b/assertions-book/assertions/ass21-ether-drain.mdx
@@ -31,7 +31,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass21EtherDrain />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [ERC20 Cumulative Outflow Breaker](/assertions-book/assertions/ass20-erc20-drain)

--- a/assertions-book/assertions/ass21-ether-drain.mdx
+++ b/assertions-book/assertions/ass21-ether-drain.mdx
@@ -17,7 +17,7 @@ Malicious actors often attempt to extract all available ETH in a single transact
 
 Implements tiered protection strategy to detect rapid ETH draining:
 
-- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture contract's ETH balance and whitelist balances before/after transaction
+- `_preTx()` / `_postTx()` with Reshiram snapshot reads: Capture contract's ETH balance and whitelist balances before/after transaction
 - `registerTxEndTrigger()`: Trigger when ETH balances change
 - For small withdrawals (below threshold): Allow regardless of destination
 - For large withdrawals (above threshold): Require destination to be whitelisted address

--- a/assertions-book/assertions/ass22-erc20-inflow-breaker.mdx
+++ b/assertions-book/assertions/ass22-erc20-inflow-breaker.mdx
@@ -32,7 +32,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass22ERC20InflowBreaker />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 

--- a/assertions-book/assertions/ass22-erc20-inflow-breaker.mdx
+++ b/assertions-book/assertions/ass22-erc20-inflow-breaker.mdx
@@ -1,0 +1,41 @@
+---
+title: 'ERC20 Cumulative Inflow Breaker'
+description: 'Limit cumulative ERC20 inflows with a Reshiram circuit-breaker trigger'
+---
+
+import ass22ERC20InflowBreaker from "/snippets/ass22-erc20-inflow-breaker.a.mdx";
+
+## When to Use This Pattern
+
+Use this pattern when unexpected inflows can distort protocol accounting, prices, or risk controls. It applies to lending vault donations, AMM reserve stuffing, bridged-asset accounting, staking receipt-token systems, and other protocols where excessive token inflow over a short window is suspicious.
+
+This is a V2 Reshiram circuit-breaker pattern. The rolling-window accounting is handled by the trigger/precompile machinery, not by assertion-authored storage.
+
+## What This Pattern Checks
+
+Registers a percentage-based cumulative inflow limit:
+
+- `registerAssertionSpec(AssertionSpec.Reshiram)`: Registers the assertion as a Reshiram assertion.
+- `watchCumulativeInflow(token, thresholdBps, windowDuration, assertFn)`: Watches ERC20 inflow over a rolling window.
+- `ph.inflowContext()`: Reads the token context inside the triggered assertion.
+- Reverts when cumulative inflow breaches the configured threshold.
+
+The assertion does not manually store balances or rolling counters. The Reshiram circuit-breaker trigger is responsible for tracking the window and invoking the assertion when the limit is exceeded.
+
+<Warning>
+As of May 6, 2026, the v2 Reshiram spec is not live on Linea mainnet. Treat this pattern as a local, development, or forward-looking example until Linea mainnet supports the spec.
+</Warning>
+
+For more information about cheatcodes, see the [Cheatcodes Documentation](/credible/cheatcodes-reference).
+
+## Assertion Pattern
+
+<ass22ERC20InflowBreaker />
+
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+
+## Related Patterns
+
+- [ERC20 Cumulative Outflow Breaker](/assertions-book/assertions/ass20-erc20-drain)
+- [ERC4626 Assets to Shares](/assertions-book/assertions/ass12-erc4626-assets-to-shares)
+- [Sum of All Positions](/assertions-book/assertions/ass08-sum-of-all-positions)

--- a/assertions-book/assertions/ass22-erc20-inflow-breaker.mdx
+++ b/assertions-book/assertions/ass22-erc20-inflow-breaker.mdx
@@ -32,7 +32,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass22ERC20InflowBreaker />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 

--- a/assertions-book/assertions/ass28-intra-tx-oracle-deviation.mdx
+++ b/assertions-book/assertions/ass28-intra-tx-oracle-deviation.mdx
@@ -15,9 +15,9 @@ Intra-transaction price manipulations can lead to flash loan attacks, theft of f
 
 Implements approach to verify oracle price updates using both pre/post state comparison and intra-transaction inspection:
 
-- `forkPreTx()` / `forkPostTx()`: Capture oracle price before and after transaction, compare for deviations
+- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture oracle price before and after transaction, compare for deviations
 - `getCallInputs()`: Monitor all price update function calls within transaction
-- `registerCallTrigger()`: Trigger when oracle price update is detected
+- `registerFnCallTrigger()`: Trigger when oracle price update is detected
 - Verify each update's price parameter against initial price
 - Enforce no price update can deviate more than maximum allowed percentage
 

--- a/assertions-book/assertions/ass28-intra-tx-oracle-deviation.mdx
+++ b/assertions-book/assertions/ass28-intra-tx-oracle-deviation.mdx
@@ -15,7 +15,7 @@ Intra-transaction price manipulations can lead to flash loan attacks, theft of f
 
 Implements approach to verify oracle price updates using both pre/post state comparison and intra-transaction inspection:
 
-- `PhEvm.ForkId({forkType: 0, callIndex: 0})` / `PhEvm.ForkId({forkType: 1, callIndex: 0})` with Reshiram snapshot reads: Capture oracle price before and after transaction, compare for deviations
+- `_preTx()` / `_postTx()` with Reshiram snapshot reads: Capture oracle price before and after transaction, compare for deviations
 - `getCallInputs()`: Monitor all price update function calls within transaction
 - `registerFnCallTrigger()`: Trigger when oracle price update is detected
 - Verify each update's price parameter against initial price

--- a/assertions-book/assertions/ass28-intra-tx-oracle-deviation.mdx
+++ b/assertions-book/assertions/ass28-intra-tx-oracle-deviation.mdx
@@ -29,7 +29,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass28IntraTxOracleDeviation />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/assertion-examples/blob/main/assertions/).</Note>
+<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
 
 ## Related Patterns
 - [Oracle Validation](/assertions-book/assertions/ass10-oracle-validation)

--- a/assertions-book/assertions/ass28-intra-tx-oracle-deviation.mdx
+++ b/assertions-book/assertions/ass28-intra-tx-oracle-deviation.mdx
@@ -29,7 +29,7 @@ For more information about cheatcodes, see the [Cheatcodes Documentation](/credi
 
 <ass28IntraTxOracleDeviation />
 
-<Note>Full examples with tests available in the [Phylax Assertion Examples Repository](https://github.com/phylaxsystems/credible-std/tree/master/src/protection).</Note>
+<Note>Full examples and mock protocol code are available in [credible-std](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).</Note>
 
 ## Related Patterns
 - [Oracle Validation](/assertions-book/assertions/ass10-oracle-validation)

--- a/assertions-book/assertions/use-cases-index.mdx
+++ b/assertions-book/assertions/use-cases-index.mdx
@@ -7,50 +7,62 @@ Use this page as a reference catalog when you already know the class of risk you
 
 ## Access Control & Administrative Changes
 
-- [**Implementation Address Change**](/assertions-book/assertions/ass01-impl-addr-change): Protects against unauthorized changes to proxy implementation addresses, preventing attackers from replacing contract logic with malicious code.
+- [**Implementation Address Change**](./ass01-impl-addr-change): Protects against unauthorized changes to proxy implementation addresses, preventing attackers from replacing contract logic with malicious code.
 
-- [**KYC Whitelist**](/assertions-book/assertions/ass04-kyc-whitelist): Ensures that only KYC accredited users can interact with a contract based on a unified KYC registry.
+- [**KYC Whitelist**](./ass04-kyc-whitelist): Ensures that only KYC accredited users can interact with a contract based on a unified KYC registry.
 
-- [**Owner Change**](/assertions-book/assertions/ass05-ownership-change): Ensures ownership of a contract cannot be transferred unexpectedly, preventing attackers from gaining administrative control over critical protocol functions.
+- [**Owner Change**](./ass05-ownership-change): Ensures ownership of a contract cannot be transferred unexpectedly, preventing attackers from gaining administrative control over critical protocol functions.
 
-- [**Timelock Verification**](/assertions-book/assertions/ass09-timelock-verification): Verifies that administrative actions are executed only after the required timelock period, preventing rushed or malicious changes to protocol parameters.
+- [**Timelock Verification**](./ass09-timelock-verification): Verifies that administrative actions are executed only after the required timelock period, preventing rushed or malicious changes to protocol parameters.
 
 ## Liquidity Pool & AMM Security
 
-- [**Constant Product**](/assertions-book/assertions/ass06-constant-product): Ensures the constant product formula (k = x * y) is maintained in AMM pools, preventing price manipulation attacks and unauthorized token drains.
+- [**Constant Product**](./ass06-constant-product): Ensures the constant product formula (k = x * y) is maintained in AMM pools, preventing price manipulation attacks and unauthorized token drains.
 
-- [**Price Within Ticks**](/assertions-book/assertions/ass15-price-within-ticks): Verifies that concentrated liquidity positions in AMM protocols maintain prices within expected tick boundaries, protecting against price manipulation.
+- [**Price Within Ticks**](./ass15-price-within-ticks): Verifies that concentrated liquidity positions in AMM protocols maintain prices within expected tick boundaries, protecting against price manipulation.
 
-- [**Fee Calculations**](/assertions-book/assertions/ass14-fee-calculations): Ensures trading fees are correctly calculated and distributed, preventing fee theft or unexpected losses in AMM protocols.
+- [**Fee Calculations**](./ass14-fee-calculations): Ensures trading fees are correctly calculated and distributed, preventing fee theft or unexpected losses in AMM protocols.
 
 ## Lending Protocol Safety
 
-- [**Lending Health Factor**](/assertions-book/assertions/ass07-lending-health-factor): Enforces minimum health factor requirements in lending protocols, preventing under-collateralized positions and protecting protocol solvency.
+- [**Lending Health Factor**](./ass07-lending-health-factor): Enforces minimum health factor requirements in lending protocols, preventing under-collateralized positions and protecting protocol solvency.
 
-- [**Liquidation Health Factor**](/assertions-book/assertions/ass16-liquidation-health-factor): Ensures liquidations only occur when health factors fall below the liquidation threshold, protecting borrowers from premature or incorrect liquidations.
+- [**Liquidation Health Factor**](./ass16-liquidation-health-factor): Ensures liquidations only occur when health factors fall below the liquidation threshold, protecting borrowers from premature or incorrect liquidations.
 
-- [**Sum of All Positions**](/assertions-book/assertions/ass08-sum-of-all-positions): Verifies that the sum of all user positions matches the total asset balance, detecting accounting errors or unauthorized fund movements.
+- [**Sum of All Positions**](./ass08-sum-of-all-positions): Verifies that the sum of all user positions matches the total asset balance, detecting accounting errors or unauthorized fund movements.
 
-- [**Tokens Borrowed Invariant**](/assertions-book/assertions/ass19-tokens-borrowed-invariant): Enforces that the relationship between borrowed tokens and collateral remains within safe protocol limits, preventing critical invariant violations.
+- [**Tokens Borrowed Invariant**](./ass19-tokens-borrowed-invariant): Enforces that the relationship between borrowed tokens and collateral remains within safe protocol limits, preventing critical invariant violations.
+
+## Oracle Security
+
+- [**Oracle Liveness Validation**](./ass10-oracle-validation): Verifies that oracle data is fresh enough for protocol operations that rely on it.
+
+- [**TWAP Deviation**](./ass11-twap-deviation): Compares pre-transaction and post-transaction TWAP values and tracks intra-transaction price changes.
+
+- [**Intra-tx Oracle Deviation**](./ass28-intra-tx-oracle-deviation): Checks that oracle price updates stay within an allowed deviation range during a transaction.
 
 ## Circuit Breakers
 
-- [**ERC20 Cumulative Outflow Breaker**](/assertions-book/assertions/ass20-erc20-drain): Uses the Reshiram `watchCumulativeOutflow` trigger to limit ERC20 outflows over a rolling window.
+- [**ERC20 Cumulative Outflow Breaker**](./ass20-erc20-drain): Uses the Reshiram `watchCumulativeOutflow` trigger to limit ERC20 outflows over a rolling window.
 
-- [**ERC20 Cumulative Inflow Breaker**](/assertions-book/assertions/ass22-erc20-inflow-breaker): Uses the Reshiram `watchCumulativeInflow` trigger to limit suspicious ERC20 inflows over a rolling window.
+- [**ERC20 Cumulative Inflow Breaker**](./ass22-erc20-inflow-breaker): Uses the Reshiram `watchCumulativeInflow` trigger to limit suspicious ERC20 inflows over a rolling window.
+
+## Native Asset Protection
+
+- [**Ether Drain**](./ass21-ether-drain): Limits sudden ETH outflows and requires trusted destinations for large withdrawals.
 
 ## Vault & ERC4626 Security
 
-- [**ERC4626 Assets to Shares**](/assertions-book/assertions/ass12-erc4626-assets-to-shares): Verifies correct conversion between assets and shares in ERC4626 vaults, preventing accounting errors that could lead to fund loss.
+- [**ERC4626 Assets to Shares**](./ass12-erc4626-assets-to-shares): Verifies correct conversion between assets and shares in ERC4626 vaults, preventing accounting errors that could lead to fund loss.
 
-- [**ERC4626 Vault Operations**](/assertions-book/assertions/ass13-erc4626-deposit-withdraw): Ensures all ERC4626 operations (deposit, withdraw, mint, redeem) maintain correct accounting, with support for batch transaction validation.
+- [**ERC4626 Deposit and Withdraw Share Price**](./ass13-erc4626-deposit-withdraw): Checks that deposit and withdraw calls do not reduce the vault share price across matched call snapshots.
 
-- [**Harvest Increases Balance**](/assertions-book/assertions/ass18-harvest-increases-balance): Verifies that yield-generating operations like harvests always increase the total balance of vaults, preventing value extraction attacks.
+- [**Harvest Increases Balance**](./ass18-harvest-increases-balance): Verifies that yield-generating operations like harvests always increase the total balance of vaults, preventing value extraction attacks.
 
 ## Emergency & Special Mode Protection
 
-- [**Panic State Validation**](/assertions-book/assertions/ass17-panic-state-validation): Validates critical protocol state variables during panic or emergency modes, ensuring fallback mechanisms work correctly when normal operations are suspended.
+- [**Panic State Validation**](./ass17-panic-state-validation): Validates critical protocol state variables during panic or emergency modes, ensuring fallback mechanisms work correctly when normal operations are suspended.
 
 ---
 
-**Next:** Explore [previous hacks analysis](/assertions-book/previous-hacks/) to see how assertions could have prevented real-world exploits.
+**Next:** Explore [previous hacks analysis](../previous-hacks/prev-hacks-index) to see how assertions could have prevented real-world exploits.

--- a/assertions-book/assertions/use-cases-index.mdx
+++ b/assertions-book/assertions/use-cases-index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Assertion Pattern Catalog
-description: Reference catalog of reusable assertion patterns organized by security category
+description: Reference catalog of reusable V2 assertion patterns organized by security category
 ---
 
 Use this page as a reference catalog when you already know the class of risk you want to cover and need a matching assertion pattern. If you want to understand a historical exploit first, use the [hack case studies](../previous-hacks/prev-hacks-index).
@@ -33,13 +33,11 @@ Use this page as a reference catalog when you already know the class of risk you
 
 - [**Tokens Borrowed Invariant**](/assertions-book/assertions/ass19-tokens-borrowed-invariant): Enforces that the relationship between borrowed tokens and collateral remains within safe protocol limits, preventing critical invariant violations.
 
-## Oracle Security
+## Circuit Breakers
 
-- [**Oracle Liveness Validation**](/assertions-book/assertions/ass10-oracle-validation): Verifies that oracle data is fresh and updated within an acceptable time window, preventing the use of stale or manipulated price data.
+- [**ERC20 Cumulative Outflow Breaker**](/assertions-book/assertions/ass20-erc20-drain): Uses the Reshiram `watchCumulativeOutflow` trigger to limit ERC20 outflows over a rolling window.
 
-- [**TWAP Deviation**](/assertions-book/assertions/ass11-twap-deviation): Ensures the time-weighted average price doesn't deviate excessively from previous values, detecting price manipulation attempts or oracle failures.
-
-- [**Intra-Transaction Oracle Deviation**](/assertions-book/assertions/ass28-intra-tx-oracle-deviation): Monitors price oracle readings during a transaction to detect excessive deviations that might indicate flash loan attacks or price manipulation.
+- [**ERC20 Cumulative Inflow Breaker**](/assertions-book/assertions/ass22-erc20-inflow-breaker): Uses the Reshiram `watchCumulativeInflow` trigger to limit suspicious ERC20 inflows over a rolling window.
 
 ## Vault & ERC4626 Security
 
@@ -52,13 +50,6 @@ Use this page as a reference catalog when you already know the class of risk you
 ## Emergency & Special Mode Protection
 
 - [**Panic State Validation**](/assertions-book/assertions/ass17-panic-state-validation): Validates critical protocol state variables during panic or emergency modes, ensuring fallback mechanisms work correctly when normal operations are suspended.
-
-
-## Fund Protection
-
-- [**ERC20 Drain**](/assertions-book/assertions/ass20-erc20-drain): Prevents excessive token outflows in a single transaction, mitigating the impact of potential exploits by limiting how quickly funds can be drained.
-
-- [**Ether Drain**](/assertions-book/assertions/ass21-ether-drain): Monitors and limits ETH outflows from contracts, protecting against unauthorized withdrawals that could deplete protocol reserves.
 
 ---
 

--- a/assertions-book/previous-hacks/abracadabra-gmx-v2-exploit.mdx
+++ b/assertions-book/previous-hacks/abracadabra-gmx-v2-exploit.mdx
@@ -38,6 +38,7 @@ The core issue was a fundamental violation of a basic invariant: reported collat
 pragma solidity 0.8.28;
 
 import {Assertion} from "../../lib/credible-std/src/Assertion.sol";
+import {AssertionSpec} from "../../lib/credible-std/src/SpecRecorder.sol";
 import {PhEvm} from "../../lib/credible-std/src/PhEvm.sol";
 
 interface IGmxV2CauldronRouterOrder {
@@ -52,11 +53,15 @@ interface IERC20 {
 }
 
 contract AbracadabraGmxV2Assertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     uint256 constant oracleDecimalScale = 1e30;
 
     function triggers() public view override {
         // Trigger on any call to sendValueInCollateral
-        registerCallTrigger(
+        registerFnCallTrigger(
             this.assertPhantomCollateral.selector,
             IGmxV2CauldronRouterOrder.sendValueInCollateral.selector
         );

--- a/assertions-book/previous-hacks/abracadabra-hack-3.mdx
+++ b/assertions-book/previous-hacks/abracadabra-hack-3.mdx
@@ -95,11 +95,11 @@ contract AbracadabraCookSolvencyAssertion is Assertion {
         address caller = calls[0].caller;
 
         // Get borrow amount before transaction
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
         uint256 borrowPartBefore = cauldron.userBorrowPart(caller);
 
         // Get borrow amount after transaction
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
         uint256 borrowPartAfter = cauldron.userBorrowPart(caller);
 
         // Only check if borrow increased

--- a/assertions-book/previous-hacks/abracadabra-hack-3.mdx
+++ b/assertions-book/previous-hacks/abracadabra-hack-3.mdx
@@ -48,6 +48,7 @@ Assertions flip this model. Rather than validating each execution path, you vali
 pragma solidity 0.8.28;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 interface ICauldronV4 {
@@ -69,10 +70,14 @@ interface IOracle {
 }
 
 contract AbracadabraCookSolvencyAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     uint256 constant COLLATERIZATION_RATE_PRECISION = 1e5;
 
     function triggers() public view override {
-        registerCallTrigger(
+        registerFnCallTrigger(
             this.assertUserSolvency.selector,
             ICauldronV4.cook.selector
         );
@@ -90,11 +95,11 @@ contract AbracadabraCookSolvencyAssertion is Assertion {
         address caller = calls[0].caller;
 
         // Get borrow amount before transaction
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 borrowPartBefore = cauldron.userBorrowPart(caller);
 
         // Get borrow amount after transaction
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 borrowPartAfter = cauldron.userBorrowPart(caller);
 
         // Only check if borrow increased

--- a/assertions-book/previous-hacks/abracadabra-rounding-error.mdx
+++ b/assertions-book/previous-hacks/abracadabra-rounding-error.mdx
@@ -65,7 +65,7 @@ contract AbracadabraRebaseInvariantAssertion is Assertion {
     function assertionNoDebtSharesIfNoDebt() external view {
         ICauldronV4 cauldron = ICauldronV4(ph.getAssertionAdopter());
 
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
         (uint128 elastic, uint128 base) = cauldron.totalBorrow();
 
         // Core invariant: if no debt exists, no shares should exist

--- a/assertions-book/previous-hacks/abracadabra-rounding-error.mdx
+++ b/assertions-book/previous-hacks/abracadabra-rounding-error.mdx
@@ -46,21 +46,26 @@ The key invariant is: **when no assets are owed (elastic = 0), there should be n
 pragma solidity 0.8.28;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 
 interface ICauldronV4 {
     function totalBorrow() external view returns (uint128 elastic, uint128 base);
 }
 
 contract AbracadabraRebaseInvariantAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     function triggers() external view override {
         // Trigger on any storage change to the cauldron
-        registerStorageChangeTrigger(this.assertionNoDebtSharesIfNoDebt.selector);
+        registerTxEndTrigger(this.assertionNoDebtSharesIfNoDebt.selector);
     }
 
     function assertionNoDebtSharesIfNoDebt() external view {
         ICauldronV4 cauldron = ICauldronV4(ph.getAssertionAdopter());
 
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         (uint128 elastic, uint128 base) = cauldron.totalBorrow();
 
         // Core invariant: if no debt exists, no shares should exist

--- a/assertions-book/previous-hacks/balancer-v2-stable-rate-exploit.mdx
+++ b/assertions-book/previous-hacks/balancer-v2-stable-rate-exploit.mdx
@@ -90,7 +90,13 @@ Rather than attempting to detect the specific exploit mechanism, we assert a sim
 ### Example Assertion
 
 ```solidity
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
 contract BatchSwapDeltaAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     uint256 constant MAX_RATE_CHANGE_MULTIPLIER = 3e18; // 3.0x
     uint256 constant MIN_RATE_CHANGE_MULTIPLIER = 33e16; // 0.33x
 
@@ -115,10 +121,10 @@ contract BatchSwapDeltaAssertion is Assertion {
                 (address poolAddress, ) = IVault(vault).getPool(uniquePoolIds[j]);
 
                 // Check rate before and after the swap
-                ph.forkPreCall(callInput.id);
+                PhEvm.ForkId memory preCallFork = PhEvm.ForkId({forkType: 2, callIndex: callInput.id});
                 uint256 preRate = IRateProvider(poolAddress).getRate();
 
-                ph.forkPostCall(callInput.id);
+                PhEvm.ForkId memory postCallFork = PhEvm.ForkId({forkType: 3, callIndex: callInput.id});
                 uint256 postRate = IRateProvider(poolAddress).getRate();
 
                 uint256 rateChangeMultiplier = (postRate * 1e18) / preRate;

--- a/assertions-book/previous-hacks/bunni-xyz-rounding-error.mdx
+++ b/assertions-book/previous-hacks/bunni-xyz-rounding-error.mdx
@@ -74,9 +74,15 @@ A rounding direction that's safe for individual operations may not be safe for m
 A withdrawal proportionality assertion could have prevented this attack by ensuring that active balance decreases are proportional to shares burned:
 
 ```solidity
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
 contract BunniWithdrawalInvariantAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     function triggers() external view override {
-        registerCallTrigger(
+        registerFnCallTrigger(
             this.assertionWithdrawalProportionality.selector,
             IBunniHub.withdraw.selector
         );
@@ -97,13 +103,13 @@ contract BunniWithdrawalInvariantAssertion is Assertion {
                 abi.decode(withdrawals[i].input, (PoolId, uint256, address, uint256));
             
             // Get pool state before withdrawal
-            ph.forkPreCall(withdrawals[i].id);
+            PhEvm.ForkId memory preCallFork = PhEvm.ForkId({forkType: 2, callIndex: withdrawals[i].id});
             uint256 totalSupplyBefore = hub.bunniTokenOfPool(poolId).totalSupply();
             uint256 activeBalance0Before = hub.getPoolBalance(poolId, 0);
             uint256 activeBalance1Before = hub.getPoolBalance(poolId, 1);
             
             // Get pool state after withdrawal
-            ph.forkPostCall(withdrawals[i].id);
+            PhEvm.ForkId memory postCallFork = PhEvm.ForkId({forkType: 3, callIndex: withdrawals[i].id});
             uint256 totalSupplyAfter = hub.bunniTokenOfPool(poolId).totalSupply();
             // Assuming `getPoolBalance` function exists for simplicity
             uint256 activeBalance0After = hub.getPoolBalance(poolId, 0);

--- a/assertions-book/previous-hacks/bybit-safe-ui.mdx
+++ b/assertions-book/previous-hacks/bybit-safe-ui.mdx
@@ -72,7 +72,8 @@ PhEvm precompiles used:
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Assertion} from "../../lib/credible-std/src/Assertion.sol"; // Credible Layer precompiles
+import {Assertion} from "../../lib/credible-std/src/Assertion.sol";
+import {AssertionSpec} from "../../lib/credible-std/src/SpecRecorder.sol"; // Credible Layer precompiles
 import {Safe} from "../../lib/safe-contracts/src/Safe.sol"; // Safe contract
 import {PhEvm} from "../../lib/credible-std/src/PhEvm.sol";
 
@@ -80,17 +81,18 @@ contract SafeAssertion is Assertion {
     Safe safe;
 
     constructor(address payable safe_) {
+        registerAssertionSpec(AssertionSpec.Reshiram);
         safe = Safe(safe_); // Define address of Safe contract
     }
 
     // Define the triggers for the assertions
     function triggers() public view override {
-        registerStorageChangeTrigger(this.implementationAddressChange.selector, bytes32(0x0));
+        registerTxEndTrigger(this.implementationAddressChange.selector);
     }
 
     function implementationAddressChange() external view {
-        ph.forkPreTx();
-        address preImplementationAddress = address(uint160(uint256(ph.load(address(safe), bytes32(0x0)))));
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+        address preImplementationAddress = address(uint160(uint256(ph.loadStateAt(address(safe), bytes32(0x0), preFork))));
 
         address[] memory addresses = getStateChangesAddress(address(safe), bytes32(0x0));
         for (uint256 i = 0; i < addresses.length; i++) {
@@ -108,14 +110,14 @@ the balance of the whitelisted addresses increased with the respective amount.
 
 ```solidity
  function assertionSafeDrain() external {
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 preBalance = address(bybitSafeAddress).balance;
         uint256[] memory preWhitelistBalances = new uint256[](whitelistedAddresses.length);
         for (uint256 i = 0; i < whitelistedAddresses.length; i++) {
             preWhitelistBalances[i] = address(whitelistedAddresses[i]).balance;
         }
 
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 postBalance = address(bybitSafeAddress).balance;
         if (postBalance > preBalance) {
             return; // Balance increased, not a hack

--- a/assertions-book/previous-hacks/bybit-safe-ui.mdx
+++ b/assertions-book/previous-hacks/bybit-safe-ui.mdx
@@ -91,7 +91,7 @@ contract SafeAssertion is Assertion {
     }
 
     function implementationAddressChange() external view {
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
         address preImplementationAddress = address(uint160(uint256(ph.loadStateAt(address(safe), bytes32(0x0), preFork))));
 
         address[] memory addresses = getStateChangesAddress(address(safe), bytes32(0x0));
@@ -110,14 +110,14 @@ the balance of the whitelisted addresses increased with the respective amount.
 
 ```solidity
  function assertionSafeDrain() external {
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
         uint256 preBalance = address(bybitSafeAddress).balance;
         uint256[] memory preWhitelistBalances = new uint256[](whitelistedAddresses.length);
         for (uint256 i = 0; i < whitelistedAddresses.length; i++) {
             preWhitelistBalances[i] = address(whitelistedAddresses[i]).balance;
         }
 
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
         uint256 postBalance = address(bybitSafeAddress).balance;
         if (postBalance > preBalance) {
             return; // Balance increased, not a hack

--- a/assertions-book/previous-hacks/compound-upgrade-bug.mdx
+++ b/assertions-book/previous-hacks/compound-upgrade-bug.mdx
@@ -30,15 +30,14 @@ This way even if a bug is introduced, it will be caught by the assertion.
 The assertion below calculates the maximum possible rate of COMP accrual and checks that a distribution does not exceed this rate.
 
 <Warning>
-The code below is **conceptual pseudo code** to illustrate the invariant that should be enforced. It uses simplified syntax for accessing storage mappings (`compound.compAccrued[supplier]`) that would not compile in actual Solidity. A real implementation would need to use proper getter functions or storage slot calculations via `ph.load()`.
+The code below is **conceptual pseudo code** to illustrate the invariant that should be enforced. It uses simplified syntax for accessing storage mappings (`compound.compAccrued[supplier]`) that would not compile in actual Solidity. A real implementation would need to use proper getter functions or storage slot calculations via `ph.loadStateAt()`.
 </Warning>
 
 ```solidity
 // CONCEPTUAL - Verify that COMP accrual never exceeds the maximum possible rate
 function assertionValidCompAccrual() external view {
     PhEvm.CallInputs[] memory distributions = ph.getCallInputs(
-        address(comptroller),
-        Comptroller.distributeSupplierComp.selector
+        address(comptroller), Comptroller.distributeSupplierComp.selector
     );
 
     for (uint256 i = 0; i < distributions.length; i++) {
@@ -46,7 +45,7 @@ function assertionValidCompAccrual() external view {
         (address cToken, address supplier) = abi.decode(distributions[i].input, (address, address));
 
         // Check COMP accrued before distribution
-        ph.forkPreCall(distributions[i].id);
+        PhEvm.ForkId memory preCallFork = PhEvm.ForkId({forkType: 2, callIndex: distributions[i].id});
         uint256 preAccrued = comptroller.compAccrued(supplier);
         uint256 supplyIndex = comptroller.compSupplyState(cToken).index;
         uint256 maxDeltaPerToken = supplyIndex - comptroller.compInitialIndex();
@@ -54,7 +53,7 @@ function assertionValidCompAccrual() external view {
         uint256 maxIncrease = supplierTokens * maxDeltaPerToken;
 
         // Check COMP accrued after distribution
-        ph.forkPostCall(distributions[i].id);
+        PhEvm.ForkId memory postCallFork = PhEvm.ForkId({forkType: 3, callIndex: distributions[i].id});
         uint256 postAccrued = comptroller.compAccrued(supplier);
 
         if (postAccrued > preAccrued) {

--- a/assertions-book/previous-hacks/cream-finance-2.mdx
+++ b/assertions-book/previous-hacks/cream-finance-2.mdx
@@ -23,7 +23,7 @@ uint256 constant MAX_DEVIATION_BPS = 500; // 5% max deviation
 
 function assertion_priceDeviation() external view {
     // Get pre-transaction prices first
-    PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+    PhEvm.ForkId memory preFork = _preTx();
     PhEvm.Log[] memory logs = ph.getLogs();
 
     // Count relevant logs to size our array
@@ -65,7 +65,7 @@ function assertion_priceDeviation() external view {
     }
 
     // Get post-transaction prices and compare
-    PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+    PhEvm.ForkId memory postFork = _postTx();
 
     for (uint256 i = 0; i < touchedAssets.length; i++) {
         uint256 postPrice = priceOracle.getPrice(touchedAssets[i]);

--- a/assertions-book/previous-hacks/cream-finance-2.mdx
+++ b/assertions-book/previous-hacks/cream-finance-2.mdx
@@ -23,7 +23,7 @@ uint256 constant MAX_DEVIATION_BPS = 500; // 5% max deviation
 
 function assertion_priceDeviation() external view {
     // Get pre-transaction prices first
-    ph.forkPreTx();
+    PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
     PhEvm.Log[] memory logs = ph.getLogs();
 
     // Count relevant logs to size our array
@@ -65,7 +65,7 @@ function assertion_priceDeviation() external view {
     }
 
     // Get post-transaction prices and compare
-    ph.forkPostTx();
+    PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
     for (uint256 i = 0; i < touchedAssets.length; i++) {
         uint256 postPrice = priceOracle.getPrice(touchedAssets[i]);

--- a/assertions-book/previous-hacks/euler-finance-donation-hack.mdx
+++ b/assertions-book/previous-hacks/euler-finance-donation-hack.mdx
@@ -67,7 +67,7 @@ The code below is **conceptual pseudo code** to illustrate the invariant that sh
 ```solidity
 // CONCEPTUAL - getModifiedAccounts() is not a real cheatcode
 function assertionNoUnsafeDebt() external view {
-    PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+    PhEvm.ForkId memory postFork = _postTx();
 
     // Get all accounts that were modified in this tx
     // NOTE: This cheatcode does not exist - this is conceptual

--- a/assertions-book/previous-hacks/euler-finance-donation-hack.mdx
+++ b/assertions-book/previous-hacks/euler-finance-donation-hack.mdx
@@ -67,7 +67,7 @@ The code below is **conceptual pseudo code** to illustrate the invariant that sh
 ```solidity
 // CONCEPTUAL - getModifiedAccounts() is not a real cheatcode
 function assertionNoUnsafeDebt() external view {
-    ph.forkPostTx();
+    PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
     // Get all accounts that were modified in this tx
     // NOTE: This cheatcode does not exist - this is conceptual

--- a/assertions-book/previous-hacks/gma-aum-jul25-hack.mdx
+++ b/assertions-book/previous-hacks/gma-aum-jul25-hack.mdx
@@ -79,11 +79,11 @@ function assertSimplifiedAUMBounds() external {
     // Core principle: AUM should closely track actual token flows
 
     // 1. Capture AUM before transaction
-    PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+    PhEvm.ForkId memory preFork = _preTx();
     uint256 aumBefore = getAumInUsdg(true);
 
     // 2. Capture AUM after transaction
-    PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+    PhEvm.ForkId memory postFork = _postTx();
     uint256 aumAfter = getAumInUsdg(true);
 
     // 3. Calculate AUM change

--- a/assertions-book/previous-hacks/gma-aum-jul25-hack.mdx
+++ b/assertions-book/previous-hacks/gma-aum-jul25-hack.mdx
@@ -79,11 +79,11 @@ function assertSimplifiedAUMBounds() external {
     // Core principle: AUM should closely track actual token flows
 
     // 1. Capture AUM before transaction
-    ph.forkPreTx();
+    PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
     uint256 aumBefore = getAumInUsdg(true);
 
     // 2. Capture AUM after transaction
-    ph.forkPostTx();
+    PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
     uint256 aumAfter = getAumInUsdg(true);
 
     // 3. Calculate AUM change

--- a/assertions-book/previous-hacks/hack1-radiant-capital.mdx
+++ b/assertions-book/previous-hacks/hack1-radiant-capital.mdx
@@ -27,6 +27,7 @@ It's a good example of how a simple assertion can be used to prevent disastrous 
 pragma solidity 0.8.28;
 
 import {Assertion} from "../lib/credible-std/Assertion.sol";
+import {AssertionSpec} from "../lib/credible-std/SpecRecorder.sol";
 
 interface ILendingPoolAddressesProvider {
     function owner() external view returns (address);
@@ -36,39 +37,43 @@ interface ILendingPoolAddressesProvider {
 
 // Radiant Lending Pool on Arbitrum that got hacked and drained
 contract LendingPoolAddressesProviderAssertions is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     ILendingPoolAddressesProvider public lendingPoolAddressesProvider =
         ILendingPoolAddressesProvider(0x091d52CacE1edc5527C99cDCFA6937C1635330E4); //arbitrum
 
     function triggers() external view override {
         // Trigger on any storage change to catch ownership modifications
-        registerStorageChangeTrigger(this.assertionOwnerChange.selector);
-        registerStorageChangeTrigger(this.assertionEmergencyAdminChange.selector);
-        registerStorageChangeTrigger(this.assertionPoolAdminChange.selector);
+        registerTxEndTrigger(this.assertionOwnerChange.selector);
+        registerTxEndTrigger(this.assertionEmergencyAdminChange.selector);
+        registerTxEndTrigger(this.assertionPoolAdminChange.selector);
     }
 
     // Check if the owner has changed
     function assertionOwnerChange() external view {
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         address prevOwner = lendingPoolAddressesProvider.owner();
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         address newOwner = lendingPoolAddressesProvider.owner();
         require(prevOwner == newOwner, "Owner has changed");
     }
 
     // Check if the emergency admin has changed
     function assertionEmergencyAdminChange() external view {
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         address prevEmergencyAdmin = lendingPoolAddressesProvider.getEmergencyAdmin();
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         address newEmergencyAdmin = lendingPoolAddressesProvider.getEmergencyAdmin();
         require(prevEmergencyAdmin == newEmergencyAdmin, "Emergency admin has changed");
     }
 
     // Check if the pool admin has changed
     function assertionPoolAdminChange() external view {
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         address prevPoolAdmin = lendingPoolAddressesProvider.getPoolAdmin();
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         address newPoolAdmin = lendingPoolAddressesProvider.getPoolAdmin();
         require(prevPoolAdmin == newPoolAdmin, "Pool admin has changed");
     }

--- a/assertions-book/previous-hacks/hack1-radiant-capital.mdx
+++ b/assertions-book/previous-hacks/hack1-radiant-capital.mdx
@@ -53,27 +53,27 @@ contract LendingPoolAddressesProviderAssertions is Assertion {
 
     // Check if the owner has changed
     function assertionOwnerChange() external view {
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
         address prevOwner = lendingPoolAddressesProvider.owner();
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
         address newOwner = lendingPoolAddressesProvider.owner();
         require(prevOwner == newOwner, "Owner has changed");
     }
 
     // Check if the emergency admin has changed
     function assertionEmergencyAdminChange() external view {
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
         address prevEmergencyAdmin = lendingPoolAddressesProvider.getEmergencyAdmin();
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
         address newEmergencyAdmin = lendingPoolAddressesProvider.getEmergencyAdmin();
         require(prevEmergencyAdmin == newEmergencyAdmin, "Emergency admin has changed");
     }
 
     // Check if the pool admin has changed
     function assertionPoolAdminChange() external view {
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
         address prevPoolAdmin = lendingPoolAddressesProvider.getPoolAdmin();
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
         address newPoolAdmin = lendingPoolAddressesProvider.getPoolAdmin();
         require(prevPoolAdmin == newPoolAdmin, "Pool admin has changed");
     }

--- a/assertions-book/previous-hacks/hack2-vestra-dao.mdx
+++ b/assertions-book/previous-hacks/hack2-vestra-dao.mdx
@@ -30,6 +30,7 @@ This would require a way to iterate over all the stakes and sum them up, which i
 pragma solidity 0.8.28;
 
 import {Assertion} from "../lib/credible-std/Assertion.sol";
+import {AssertionSpec} from "../lib/credible-std/SpecRecorder.sol";
 
 // VestraDAO interface
 interface IVestraDAO {
@@ -48,10 +49,14 @@ interface IVestraDAO {
 }
 
 contract VestraDAOHack is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     IVestraDAO public vestraDAO = IVestraDAO(address(0xbeef));
 
     function triggers() external view override {
-        registerCallTrigger(this.assertionExample.selector, vestraDAO.unStake.selector);
+        registerFnCallTrigger(this.assertionExample.selector, vestraDAO.unStake.selector);
     }
 
     // Check that user was actively staked before unstaking
@@ -64,7 +69,7 @@ contract VestraDAOHack is Assertion {
             address from = unStakes[i].caller;
 
             // Check BEFORE the unstake that the stake was active
-            ph.forkPreCall(unStakes[i].id);
+            PhEvm.ForkId memory preCallFork = PhEvm.ForkId({forkType: 2, callIndex: unStakes[i].id});
             (,,,,,bool wasActive) = vestraDAO.stakes(from, maturity);
             require(wasActive, "User was not actively staked for this maturity");
         }

--- a/assertions-book/previous-hacks/uxlink-multisig-hack.mdx
+++ b/assertions-book/previous-hacks/uxlink-multisig-hack.mdx
@@ -47,10 +47,15 @@ Multisig protection assertions could have prevented this attack by enforcing gov
 pragma solidity 0.8.28;
 
 import {Assertion} from "../../lib/credible-std/src/Assertion.sol";
+import {AssertionSpec} from "../../lib/credible-std/src/SpecRecorder.sol";
 import {PhEvm} from "../../lib/credible-std/src/PhEvm.sol";
 import {ISafe} from "@safe-global/safe-contracts/contracts/interfaces/ISafe.sol";
 
 contract UxLinkMultisigProtectionAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     // Minimum threshold that must be maintained
     uint256 constant MIN_THRESHOLD = 2;
 
@@ -60,17 +65,17 @@ contract UxLinkMultisigProtectionAssertion is Assertion {
     address constant ALLOWED_OWNER_3 = 0x3333333333333333333333333333333333333333;
 
     function triggers() external view override {
-        registerCallTrigger(
+        registerFnCallTrigger(
             this.assertThresholdProtection.selector,
             ISafe.changeThreshold.selector
         );
 
-        registerCallTrigger(
+        registerFnCallTrigger(
             this.assertOwnerAddition.selector,
             ISafe.addOwnerWithThreshold.selector
         );
 
-        registerCallTrigger(
+        registerFnCallTrigger(
             this.assertOwnerRemoval.selector,
             ISafe.removeOwner.selector
         );

--- a/assertions-book/previous-hacks/vicuna-finance-hack.mdx
+++ b/assertions-book/previous-hacks/vicuna-finance-hack.mdx
@@ -21,13 +21,13 @@ A targeted price deviation check on all calls could have prevented this oracle m
 ```solidity
 function assertPriceDeviation() external view {
     BeetsLP assertionAdopter = BeetsLP(ph.getAssertionAdopter());
-    ph.forkPreTx();
+    PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
     uint256 preOraclePrice = oracle.getPrice(token); // Get the price before the transaction
 
     // Using swap calls as an example, but any call that affects price should be checked
     PhEvm.CallInputs[] memory calls = ph.getCallInputs(address(assertionAdopter), assertionAdopter.swap.selector);
     for (uint256 i = 0; i < calls.length; i++) {
-        ph.forkPostCall(calls[i].id);
+        PhEvm.ForkId memory postCallFork = PhEvm.ForkId({forkType: 3, callIndex: calls[i].id});
         
         uint256 postOraclePrice = oracle.getPrice(token);
 
@@ -43,9 +43,9 @@ function assertPriceDeviation() external view {
 This assertion function detects oracle price manipulation by monitoring how each call affects prices.
 
 **How it works:**
-1. **Captures baseline**: Uses `ph.forkPreTx()` to get the oracle price before any calls
+1. **Captures baseline**: Uses `PhEvm.ForkId({forkType: 0, callIndex: 0})` with a Reshiram snapshot read to get the oracle price before any calls
 2. **Monitors each call**: Iterates through calls (like swaps) that could affect the oracle price
-3. **Checks price impact**: Uses `ph.forkPostCall()` to see how each call changed the oracle price
+3. **Checks price impact**: Uses a post-call `ForkId` with `ph.loadStateAt()` to see how each call changed the oracle price
 4. **Enforces limits**: Reverts if any single call causes >5% price deviation from the baseline
 
 Using Phylax cheatcodes allows checking the oracle price at every call in the transaction, detecting price manipulation as it happens and preventing attacks that rely on temporary price distortions.

--- a/assertions-book/previous-hacks/vicuna-finance-hack.mdx
+++ b/assertions-book/previous-hacks/vicuna-finance-hack.mdx
@@ -21,7 +21,7 @@ A targeted price deviation check on all calls could have prevented this oracle m
 ```solidity
 function assertPriceDeviation() external view {
     BeetsLP assertionAdopter = BeetsLP(ph.getAssertionAdopter());
-    PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+    PhEvm.ForkId memory preFork = _preTx();
     uint256 preOraclePrice = oracle.getPrice(token); // Get the price before the transaction
 
     // Using swap calls as an example, but any call that affects price should be checked
@@ -43,7 +43,7 @@ function assertPriceDeviation() external view {
 This assertion function detects oracle price manipulation by monitoring how each call affects prices.
 
 **How it works:**
-1. **Captures baseline**: Uses `PhEvm.ForkId({forkType: 0, callIndex: 0})` with a Reshiram snapshot read to get the oracle price before any calls
+1. **Captures baseline**: Uses `_preTx()` with a Reshiram snapshot read to get the oracle price before any calls
 2. **Monitors each call**: Iterates through calls (like swaps) that could affect the oracle price
 3. **Checks price impact**: Uses a post-call `ForkId` with `ph.loadStateAt()` to see how each call changed the oracle price
 4. **Enforces limits**: Reverts if any single call causes >5% price deviation from the baseline

--- a/assertions-book/previous-hacks/visor-finance-unrestricted-mint.mdx
+++ b/assertions-book/previous-hacks/visor-finance-unrestricted-mint.mdx
@@ -34,12 +34,12 @@ The assertion could be triggered by a call to the deposit function.
 ```solidity
 function assertion_triggerDeposit_remainsSolvent() public view {
     // Get pre-transaction state
-    ph.forkPreTx();
+    PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
     uint256 preBalanceCollateral = visr.balanceOf(address(adopter));
     uint256 preTotalSupplyRewards = vvisr.totalSupply();
 
     // Get post-transaction state
-    ph.forkPostTx();
+    PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
     uint256 postBalanceCollateral = visr.balanceOf(address(adopter));
     uint256 postTotalSupplyRewards = vvisr.totalSupply();
 

--- a/assertions-book/previous-hacks/visor-finance-unrestricted-mint.mdx
+++ b/assertions-book/previous-hacks/visor-finance-unrestricted-mint.mdx
@@ -34,12 +34,12 @@ The assertion could be triggered by a call to the deposit function.
 ```solidity
 function assertion_triggerDeposit_remainsSolvent() public view {
     // Get pre-transaction state
-    PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+    PhEvm.ForkId memory preFork = _preTx();
     uint256 preBalanceCollateral = visr.balanceOf(address(adopter));
     uint256 preTotalSupplyRewards = vvisr.totalSupply();
 
     // Get post-transaction state
-    PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+    PhEvm.ForkId memory postFork = _postTx();
     uint256 postBalanceCollateral = visr.balanceOf(address(adopter));
     uint256 postTotalSupplyRewards = vvisr.totalSupply();
 

--- a/credible/assertions-overview.mdx
+++ b/credible/assertions-overview.mdx
@@ -19,8 +19,8 @@ When a transaction is submitted to the network:
 
 ```solidity
 function checkOwnershipChange() external view {
-    PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
-    PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+    PhEvm.ForkId memory preTx = _preTx();
+    PhEvm.ForkId memory postTx = _postTx();
 
     address ownerBefore = address(uint160(uint256(ph.loadStateAt(address(protocol), bytes32(uint256(0)), preTx))));
     address ownerAfter = address(uint160(uint256(ph.loadStateAt(address(protocol), bytes32(uint256(0)), postTx))));

--- a/credible/assertions-overview.mdx
+++ b/credible/assertions-overview.mdx
@@ -18,14 +18,12 @@ When a transaction is submitted to the network:
 ## Example: Prevent Unauthorized Ownership Changes
 
 ```solidity
-function checkOwnershipChange() external {
-    // Fork to state before transaction
-    ph.forkPreTx();
-    address ownerBefore = protocol.owner();
+function checkOwnershipChange() external view {
+    PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
+    PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
-    // Fork to state after transaction
-    ph.forkPostTx();
-    address ownerAfter = protocol.owner();
+    address ownerBefore = address(uint160(uint256(ph.loadStateAt(address(protocol), bytes32(uint256(0)), preTx))));
+    address ownerAfter = address(uint160(uint256(ph.loadStateAt(address(protocol), bytes32(uint256(0)), postTx))));
 
     require(ownerBefore == ownerAfter, "Owner cannot change");
 }
@@ -36,7 +34,7 @@ When a transaction tries to change the owner, this assertion runs. If the owner 
 ## What They Can Do That Regular Solidity Can't
 
 **Compare before/after states**
-Regular Solidity only sees the current state during execution. Assertions can compare values before and after a transaction using [cheatcodes](/credible/glossary#cheatcodes) like `ph.forkPreTx()` and `ph.forkPostTx()`. You can also inspect state at any point during execution using `ph.forkPreCall()` and `ph.forkPostCall()` to check individual nested calls within the transaction.
+Regular Solidity only sees the current state during execution. Assertions can compare values before and after a transaction using [cheatcodes](/credible/glossary#cheatcodes) like `ph.loadStateAt` with explicit `ForkId` snapshots. You can also inspect state around a specific matched call by combining `ph.context()` with call-scoped `ForkId` values.
 
 **Protect immutable contracts**
 You can add assertions to contracts without modifying them. No redeployment needed.

--- a/credible/cheatcodes-overview.mdx
+++ b/credible/cheatcodes-overview.mdx
@@ -9,10 +9,10 @@ Cheatcodes are specialized testing and assertion utilities in the Phylax Credibl
 
 Cheatcodes enable functionality that would be impossible or impractical with standard Solidity:
 
-- **Forking blockchain state**: Access the state of the blockchain before and after a transaction, enabling pre/post comparisons
+- **Snapshot state access**: Access blockchain state before or after a transaction or call with explicit `ForkId` snapshots
 - **Callstack introspection**: Inspect call traces and execution flow in ways not possible with standard EVM tools
 - **State change tracking**: Monitor specific storage slots and track how they change during transaction execution
-- **Triggering assertions**: Define precise conditions for when assertions should execute (specific function calls, storage changes, or balance changes)
+- **Triggering assertions**: Define precise conditions for when assertions should execute with `onFnCall` and `onTxEnd` triggers
 
 ## Why Cheatcodes Exist
 
@@ -42,11 +42,15 @@ Use cheatcodes when you need to:
 New to assertions? Check out [What are Assertions?](/credible/assertions-overview) to understand how cheatcodes fit into the bigger picture of writing security rules.
 </Note>
 
-## State Forking Guidance
+## Snapshot Read Guidance
 
 Not all assertions require checking both pre- and post-state. Understanding when to use each makes assertions more efficient.
 
-**Default behavior:** If neither `ph.forkPreTx()` nor `ph.forkPostTx()` are called, assertions execute against post-transaction state by default.
+<Warning>
+As of May 6, 2026, the v2 Reshiram spec is not live on Linea mainnet. Treat Reshiram-only precompile and trigger examples as local, development, or forward-looking references until Linea mainnet supports the spec.
+</Warning>
+
+Prefer Reshiram snapshot reads for new assertions. Use explicit `PhEvm.ForkId` values with `ph.loadStateAt()` for transaction-wide comparisons, or `ph.context()` with call-scoped `ForkId` values inside an `onFnCall` assertion.
 
 ### When to Use Pre-State
 

--- a/credible/cheatcodes-reference.mdx
+++ b/credible/cheatcodes-reference.mdx
@@ -70,8 +70,8 @@ struct ForkId {
 Construct `ForkId` values explicitly:
 
 ```solidity
-PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
-PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+PhEvm.ForkId memory preTx = _preTx();
+PhEvm.ForkId memory postTx = _postTx();
 PhEvm.ForkId memory preCall = PhEvm.ForkId({forkType: 2, callIndex: callId});
 PhEvm.ForkId memory postCall = PhEvm.ForkId({forkType: 3, callIndex: callId});
 ```
@@ -828,7 +828,7 @@ Switches the active fork to the state before the assertion-triggering transactio
 function forkPreTx() external;
 ```
 
-Use `loadStateAt(..., PhEvm.ForkId({forkType: 0, callIndex: 0}))` instead.
+Use `loadStateAt(..., _preTx())` instead.
 
 ### `forkPostTx`
 
@@ -838,7 +838,7 @@ Switches the active fork to the state after the assertion-triggering transaction
 function forkPostTx() external;
 ```
 
-Use `loadStateAt(..., PhEvm.ForkId({forkType: 1, callIndex: 0}))` instead.
+Use `loadStateAt(..., _postTx())` instead.
 
 ### `forkPreCall`
 

--- a/credible/cheatcodes-reference.mdx
+++ b/credible/cheatcodes-reference.mdx
@@ -1,111 +1,154 @@
 ---
 title: 'Cheatcodes API Reference'
-description: 'Complete API reference for cheatcodes in the Phylax Credible Layer'
+description: 'Reference for deprecated, legacy, and Reshiram cheatcodes in the Phylax Credible Layer'
 ---
 
 <Note>
-New to cheatcodes? Start with [What are Cheatcodes?](/credible/cheatcodes-overview) to understand what they are and why they exist.
+New to cheatcodes? Start with [What are Cheatcodes?](./cheatcodes-overview) to understand what they are and why they exist.
 </Note>
 
-## State Management
+This reference lists the Credible Layer cheatcodes exposed through `credible-std`.
 
-### `forkPreTx`
+Cheatcodes are grouped by API status:
 
-Updates the active fork to the state prior to the assertion triggering transaction. Useful for:
-- Checking chain state before a transaction
-- Comparing values between pre and post states
+- **Legacy precompiles**: launch-era APIs that remain part of the legacy assertion surface.
+- **Reshiram precompiles**: newer APIs based on explicit `ForkId` snapshot reads, call context, richer log and call inspection, and protection-suite helpers.
+- **Deprecated cheatcodes**: legacy fork-switching APIs. Do not use them in new assertions.
 
-```solidity
-function forkPreTx() external
-```
+<Warning>
+As of May 6, 2026, the v2 Reshiram spec is not live on Linea mainnet. Do not assume Reshiram-only precompiles or `onFnCall` and `onTxEnd` triggers are available on Linea mainnet until that rollout is live.
+</Warning>
 
-### `forkPostTx`
+## Assertion Specs
 
-Updates the active fork to the state after the assertion triggering transaction. Useful for:
-- Verifying chain state after a transaction
-- Comparing values between pre and post states
+`credible-std` defines assertion specs in `SpecRecorder.sol`.
 
 ```solidity
-function forkPostTx() external
+enum AssertionSpec {
+    Legacy,
+    Reshiram,
+    Experimental
+}
 ```
 
-### `forkPreCall`
+| Spec | Availability |
+| --- | --- |
+| `Legacy` | Standard launch precompile set. Reshiram-only precompiles are unavailable. |
+| `Reshiram` | Reshiram precompiles plus the non-deprecated shared surface. Legacy-only fork-switching selectors are unavailable. |
+| `Experimental` | Unrestricted access to all available precompiles. May include untested or dangerous behavior. |
 
-Updates the active fork to the state at the start of call execution for the specified id. `getCallInputs(..)` can be used to get ids to fork to.
+Register the spec in the assertion constructor:
 
 ```solidity
-function forkPreCall(uint256 id) external
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
+constructor() {
+    registerAssertionSpec(AssertionSpec.Reshiram);
+}
 ```
 
-### `forkPostCall`
+## Common Types
 
-Updates the active fork to the state after the call execution for the specified id. `getCallInputs(..)` can be used to get ids to fork to.
+### `ForkId`
+
+Identifies an immutable transaction snapshot.
 
 ```solidity
-function forkPostCall(uint256 id) external
+struct ForkId {
+    uint8 forkType;
+    uint256 callIndex;
+}
 ```
 
-## Storage Operations
+| `forkType` | Snapshot |
+| --- | --- |
+| `0` | `PreTx` |
+| `1` | `PostTx` |
+| `2` | `PreCall(callIndex)` |
+| `3` | `PostCall(callIndex)` |
 
-### `load`
-
-Loads a storage slot from an address.
-
-<Note>
-Using `forge inspect <ContractName> storage-layout` is an easy way to get the storage layout of a contract. This can be used to determine the storage slot of a specific variable to use in the cheatcode.
-</Note>
+Construct `ForkId` values explicitly:
 
 ```solidity
-function load(
-    address target,
-    bytes32 slot
-) external view returns (bytes32 data)
+PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
+PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+PhEvm.ForkId memory preCall = PhEvm.ForkId({forkType: 2, callIndex: callId});
+PhEvm.ForkId memory postCall = PhEvm.ForkId({forkType: 3, callIndex: callId});
 ```
 
-You can see an example of how to use this cheatcode in the [Storage Lookups](/credible/use-case-mappings/storage-lookups) use case mapping.
+### `Log`
 
-## Transaction Data
-
-### `getLogs`
-
-Retrieves logs from the assertion triggering transaction.
+Represents an Ethereum log emitted during transaction execution.
 
 ```solidity
 struct Log {
-    bytes32[] topics;   // Log topics, including signature
-    bytes data;         // Raw log data
-    address emitter;    // Log emitter address
+    bytes32[] topics;
+    bytes data;
+    address emitter;
 }
-
-function getLogs() external returns (Log[] memory logs)
 ```
 
-You can see an example of how to use this cheatcode in the [Read Logs](/credible/use-case-mappings/read-logs) use case mapping.
+### `LogQuery`
 
-### `getAllCallInputs`
+Filters logs by emitter and signature.
 
-Gets all call inputs for a given target and selector. This includes all types of calls (CALL, STATICCALL, DELEGATECALL, CALLCODE).
+```solidity
+struct LogQuery {
+    address emitter;
+    bytes32 signature;
+}
+```
+
+`address(0)` matches any emitter. `bytes32(0)` matches any topic0 signature.
+
+### `CallInputs`
+
+Represents call input data recorded during transaction execution.
 
 ```solidity
 struct CallInputs {
-    bytes input;                // Call data
-    uint64 gas_limit;           // Gas limit
-    address bytecode_address;   // Code execution address
-    address target_address;     // Storage modification target
-    address caller;             // Transaction caller
-    uint256 value;              // Call value
-    uint256 id;                 // Call id (used for forkPreCall and forkPostCall)
+    bytes input;
+    uint64 gas_limit;
+    address bytecode_address;
+    address target_address;
+    address caller;
+    uint256 value;
+    uint256 id;
 }
+```
 
+Use `id` with call-scoped APIs such as `PhEvm.ForkId({forkType: 2, callIndex: id})`, `PhEvm.ForkId({forkType: 3, callIndex: id})`, `callinputAt(id)`, `callOutputAt(id)`, and `getLogsForCall(query, id)`.
+
+## Legacy Precompiles
+
+Legacy precompiles are the standard launch-era cheatcodes. Some are still useful, but prefer the Reshiram equivalents when you need explicit snapshot selection or call-scoped behavior.
+
+### `getLogs`
+
+Returns all logs emitted during the assertion-triggering transaction.
+
+```solidity
+function getLogs() external returns (Log[] memory logs);
+```
+
+Use `getLogsQuery(query, fork)` when you need emitter or signature filtering, or `getLogsForCall(query, callId)` when you need call-scoped logs.
+
+### `getAllCallInputs`
+
+Gets call inputs for a target and selector across `CALL`, `STATICCALL`, `DELEGATECALL`, and `CALLCODE`.
+
+```solidity
 function getAllCallInputs(
     address target,
     bytes4 selector
 ) external view returns (CallInputs[] memory calls);
 ```
 
+Prefer the opcode-specific functions below when you need to avoid double counting through proxies.
+
 ### `getCallInputs`
 
-Gets call inputs for a given target and selector. Only includes calls made using 'CALL' opcode.
+Gets call inputs for `CALL` opcodes only.
 
 ```solidity
 function getCallInputs(
@@ -114,11 +157,9 @@ function getCallInputs(
 ) external view returns (CallInputs[] memory calls);
 ```
 
-You can see an example of how to use this cheatcode in the [Function Call Inputs](/credible/use-case-mappings/function-call-inputs) use case mapping.
-
 ### `getStaticCallInputs`
 
-Gets static call inputs for a given target and selector. Only includes calls made using 'STATICCALL' opcode.
+Gets call inputs for `STATICCALL` opcodes only.
 
 ```solidity
 function getStaticCallInputs(
@@ -129,7 +170,7 @@ function getStaticCallInputs(
 
 ### `getDelegateCallInputs`
 
-Gets delegate call inputs for a given target and selector. Only includes calls made using 'DELEGATECALL' opcode.
+Gets call inputs for `DELEGATECALL` opcodes only.
 
 ```solidity
 function getDelegateCallInputs(
@@ -140,7 +181,7 @@ function getDelegateCallInputs(
 
 ### `getCallCodeInputs`
 
-Gets call code inputs for a given target and selector. Only includes calls made using 'CALLCODE' opcode.
+Gets call inputs for `CALLCODE` opcodes only.
 
 ```solidity
 function getCallCodeInputs(
@@ -149,60 +190,13 @@ function getCallCodeInputs(
 ) external view returns (CallInputs[] memory calls);
 ```
 
-### Avoiding Double-Counting with Call Inputs
-
-The specific call input cheatcodes (`getCallInputs`, `getStaticCallInputs`, `getDelegateCallInputs`, `getCallCodeInputs`) eliminate double-counting issues by allowing you to target only the specific call type you need. Use these instead of `getAllCallInputs()` when you want to avoid duplicate entries from proxy contracts.
-
-For example, if you're monitoring a proxy contract and only want the actual delegate calls (not the proxy calls), use `getDelegateCallInputs()` instead of `getAllCallInputs()`.
-
-```solidity
-// GOOD: Only get delegate calls, no duplicates
-CallInputs[] memory delegateCalls = ph.getDelegateCallInputs(target, selector);
-
-// AVOID: May include both proxy and delegate calls for the same operation
-CallInputs[] memory allCalls = ph.getAllCallInputs(target, selector);
-```
-
-If you must use `getAllCallInputs()`, you may still need to filter out proxy calls:
-
-```solidity
-// Filter proxy calls when using getAllCallInputs
-for (uint256 i = 0; i < callInputs.length; i++) {
-  if (callInputs[i].bytecode_address == callInputs[i].target_address) {
-    continue; // Skip proxy calls, only process delegate calls
-  }
-  // Process the actual call
-}
-```
-
 <Info>
-Internal calls are not actual EVM calls but rather a Solidity language feature. They are not traced by the CallTracer and will not result in `CallInputs` or trigger call-based assertions. However, using the `this` keyword (e.g., `this.functionName()`) creates an external call that will be traced and can trigger assertions.
-
-Example:
-```solidity
-function foo() external {
-    // Internal call - not traced, no CallInputs generated
-    bar();
-
-    // External call via 'this' - traced, generates CallInputs
-    this.bar();
-}
-
-function bar() public {
-    // Function implementation
-}
-```
+Internal Solidity calls are not EVM calls and are not recorded by the call tracer. Calls made through `this.someFunction()` are external calls and can be recorded.
 </Info>
-
-## State Change Tracking
 
 ### `getStateChanges`
 
-Returns state changes for a contract's storage slot within the current call stack.
-
-<Note>
-Using `forge inspect <ContractName> storage-layout` is an easy way to get the storage layout of a contract. This can be used to determine the storage slot of a specific variable to use in the cheatcode.
-</Note>
+Returns the sequence of values for a storage slot during transaction execution.
 
 ```solidity
 function getStateChanges(
@@ -211,215 +205,670 @@ function getStateChanges(
 ) external view returns (bytes32[] memory stateChanges);
 ```
 
-You can see an example of how to use this cheatcode in the [State Changes](/credible/use-case-mappings/state-changes) use case mapping.
+The returned array includes the initial value as the first element. The length is either `0` or at least `2`.
 
-<Note>
-The array returned includes the initial value of the slot as the first element, so the length of the array is either 0 or >= 2.
-</Note>
+### State Change Helpers
 
-### Helper Functions
-
-The following helpers convert state changes to specific types. Each has three variants:
-- Basic: Get changes for a single slot
-- Mapping: Get changes using a mapping key
-- Mapping with Offset: Get changes using a key and offset for complex storage
-
-#### `getStateChangesUint`
-
-Gets state changes for a storage slot as uint256 values.
+`StateChanges.sol` provides typed helpers for reading slot changes as common Solidity types.
 
 ```solidity
-// Basic
 function getStateChangesUint(
     address target,
     bytes32 slot
-) internal view returns (uint256[] memory)
+) internal view returns (uint256[] memory);
 
-// With mapping
-function getStateChangesUint(
+function getStateChangesAddress(
     address target,
-    bytes32 slot,
-    uint256 key
-) internal view returns (uint256[] memory)
-
-// With mapping and offset
-function getStateChangesUint(
-    address target,
-    bytes32 slot,
-    uint256 key,
-    uint256 offset
-) internal view returns (uint256[] memory)
-```
-
-Similar helper functions exist for:
-- `getStateChangesAddress`: Convert to address values
-- `getStateChangesBool`: Convert to boolean values
-- `getStateChangesBytes32`: Get raw bytes32 values
-
-Each of these functions follows the same pattern with basic, mapping, and mapping-with-offset variants.
-
-## Triggers
-
-Triggers determine when your assertion functions will be executed. You can register different types of triggers in your assertion's `triggers()` function.
-
-<Note>
-Use triggers to ensure that assertions are only called when they are needed in order to save gas and resources. For example, instead of triggering an assertion on every call to a contract, you can trigger it only on specific function calls that are able to change the state of the specific value you are asserting on.
-</Note>
-
-### Call Triggers
-
-Call triggers execute your assertion when specific contract calls occur.
-
-```solidity
-// Trigger on any call to the contract
-// Note: It is not recommended to use this trigger as it will trigger the assertion on every call to the contract
-// This can be expensive and inefficient
-function registerCallTrigger(
-    bytes4 assertionFnSelector
-) internal view
-
-// Trigger on specific function calls
-function registerCallTrigger(
-    bytes4 assertionFnSelector,
-    bytes4 triggerSelector
-) internal view
-```
-
-Example:
-```solidity
-function triggers() external view override {
-    // Run assertion on ALL calls to the contract
-    registerCallTrigger(this.checkAllCalls.selector);
-
-    // Run assertion only on transfer calls
-    registerCallTrigger(
-        this.checkTransfer.selector,
-        IERC20.transfer.selector
-    );
-}
-```
-
-### Storage Triggers
-
-Storage triggers execute your assertion when contract storage changes.
-
-<Note>
-Using `forge inspect <ContractName> storage-layout` is an easy way to get the storage layout of a contract. This can be used to determine the storage slot of a specific variable to use in the cheatcode.
-</Note>
-
-```solidity
-// Trigger on ANY storage slot change
-// Note: It is not recommended to use this trigger as it will trigger the assertion on every storage slot change
-// This can be expensive and inefficient
-function registerStorageChangeTrigger(
-    bytes4 assertionFnSelector
-) internal view
-
-// Trigger on changes to a specific storage slot
-function registerStorageChangeTrigger(
-    bytes4 assertionFnSelector,
     bytes32 slot
-) internal view
+) internal view returns (address[] memory);
+
+function getStateChangesBool(
+    address target,
+    bytes32 slot
+) internal view returns (bool[] memory);
+
+function getStateChangesBytes32(
+    address target,
+    bytes32 slot
+) internal view returns (bytes32[] memory);
 ```
 
-Example:
-```solidity
-function triggers() external view override {
-    // Run assertion on ANY storage change
-    registerStorageChangeTrigger(this.checkAllStorage.selector);
-
-    // Run assertion when totalSupply slot changes
-    registerStorageChangeTrigger(
-        this.checkSupply.selector,
-        TOTAL_SUPPLY_SLOT
-    );
-}
-```
-
-### Balance Triggers
-
-Executes assertion on ETH balance changes.
-
-```solidity
-function registerBalanceChangeTrigger(
-    bytes4 assertionFnSelector
-) internal view
-```
-
-### Combining Triggers
-
-Triggers can be combined for comprehensive coverage:
-
-```solidity
-function triggers() external view override {
-    // Multiple triggers for one assertion
-    registerStorageChangeTrigger(this.mainInvariant.selector);
-    registerCallTrigger(this.mainInvariant.selector);
-
-    // Different assertions for different events
-    registerBalanceChangeTrigger(this.checkBalances.selector);
-    registerCallTrigger(
-        this.checkCalls.selector,
-        IERC20.transfer.selector
-    );
-}
-```
-
-## Helpers
+The helper family also includes mapping-key and mapping-key-with-offset variants.
 
 ### `getAssertionAdopter`
 
-Get assertion adopter contract address associated with the assertion triggering transaction.
+Returns the assertion adopter contract address associated with the current transaction.
 
 ```solidity
 function getAssertionAdopter() external view returns (address);
 ```
 
-This cheatcode removes the need to define an assertion adopter contract in the assertion contract constructor.
-
-The cheatcode is only available in the `triggers()` function and the assertion functions. It cannot be used in the constructor since assertion contracts have no state during deployment.
+This cheatcode is available in `triggers()` and assertion functions. It is not available in the constructor because assertion contracts have no state during deployment.
 
 ### `console.log`
 
-Prints debug information to the console during testing with `pcl test`. Useful for debugging assertion logic and understanding transaction flow.
+Prints debug information during local assertion testing.
 
 ```solidity
 function console.log(string memory message) external;
 ```
 
-Example:
+Import it from `credible-std/Console.sol`.
+
+## Legacy Trigger Registration
+
+Legacy trigger registration functions are internal helpers on `Assertion`.
+
+### `registerCallTrigger`
+
+Registers an assertion function to run when the adopter receives a call.
+
 ```solidity
-import { console } from "credible-std/console.sol";
+function registerCallTrigger(
+    bytes4 assertionFnSelector
+) internal view;
 
-function assertionExample() external {
-    ph.forkPreTx();
-    uint256 preBalance = token.balanceOf(user);
+function registerCallTrigger(
+    bytes4 assertionFnSelector,
+    bytes4 triggerSelector
+) internal view;
+```
 
-    ph.forkPostTx();
-    uint256 postBalance = token.balanceOf(user);
+The one-argument overload triggers on any call to the adopter. The two-argument overload triggers on calls matching `triggerSelector`.
 
-    console.log("Checking user balance assertion");
+### `registerStorageChangeTrigger`
 
-    require(postBalance >= preBalance, "Balance should not decrease");
+Registers an assertion function to run when adopter storage changes.
+
+```solidity
+function registerStorageChangeTrigger(
+    bytes4 assertionFnSelector
+) internal view;
+
+function registerStorageChangeTrigger(
+    bytes4 assertionFnSelector,
+    bytes32 slot
+) internal view;
+```
+
+The one-argument overload triggers on any storage slot change. The two-argument overload triggers on a specific slot.
+
+### `registerBalanceChangeTrigger`
+
+Registers an assertion function to run when the adopter's ETH balance changes.
+
+```solidity
+function registerBalanceChangeTrigger(
+    bytes4 assertionFnSelector
+) internal view;
+```
+
+## Reshiram Precompiles
+
+Reshiram precompiles use explicit snapshot reads instead of global fork switching. In `credible-sdk`, these live under `crates/assertion-executor/src/inspectors/precompiles/reshiram/`.
+
+### State Access
+
+#### `loadStateAt`
+
+Reads a storage slot from a snapshot fork.
+
+```solidity
+function loadStateAt(
+    bytes32 slot,
+    ForkId calldata fork
+) external view returns (bytes32 value);
+
+function loadStateAt(
+    address target,
+    bytes32 slot,
+    ForkId calldata fork
+) external view returns (bytes32 value);
+```
+
+The first overload reads from the current assertion adopter. The second overload reads from any target account.
+
+#### `staticcallAt`
+
+Executes a read-only call against a snapshot fork.
+
+```solidity
+struct StaticCallResult {
+    bool ok;
+    bytes data;
+}
+
+function staticcallAt(
+    address target,
+    bytes calldata data,
+    uint64 gas_limit,
+    ForkId calldata fork
+) external view returns (StaticCallResult memory result);
+```
+
+`data` contains return data when `ok` is `true` and revert data when `ok` is `false`.
+
+### Logs
+
+#### `getLogsQuery`
+
+Returns logs matching an emitter/signature query from a snapshot fork.
+
+```solidity
+function getLogsQuery(
+    LogQuery calldata query,
+    ForkId calldata fork
+) external view returns (Log[] memory logs);
+```
+
+#### `getLogsForCall`
+
+Returns logs matching a query from one recorded call frame.
+
+```solidity
+function getLogsForCall(
+    LogQuery calldata query,
+    uint256 callId
+) external view returns (Log[] memory logs);
+```
+
+### Call Inspection
+
+#### `callinputAt`
+
+Returns the raw calldata for a traced call.
+
+```solidity
+function callinputAt(
+    uint256 callId
+) external view returns (bytes memory input);
+```
+
+#### `callOutputAt`
+
+Returns the raw return or revert bytes for a traced call.
+
+```solidity
+function callOutputAt(
+    uint256 callId
+) external view returns (bytes memory output);
+```
+
+#### `matchingCalls`
+
+Returns recorded calls matching target, selector, and filter criteria.
+
+```solidity
+struct CallFilter {
+    uint8 callType;
+    uint32 minDepth;
+    uint32 maxDepth;
+    bool topLevelOnly;
+    bool successOnly;
+}
+
+struct TriggerCall {
+    uint256 callId;
+    uint256 parentCallId;
+    address caller;
+    address target;
+    address codeAddress;
+    bytes4 selector;
+    uint32 depth;
+    uint8 callType;
+    bool success;
+    uint256 value;
+    bytes input;
+}
+
+function matchingCalls(
+    address target,
+    bytes4 selector,
+    CallFilter calldata filter,
+    uint256 limit
+) external view returns (TriggerCall[] memory calls);
+```
+
+`callType` uses `0` for any, `1` for `CALL`, `2` for `STATICCALL`, `3` for `DELEGATECALL`, and `4` for `CALLCODE`.
+
+### Trigger Context
+
+#### `context`
+
+Returns context for the current `registerFnCallTrigger` invocation.
+
+```solidity
+struct TriggerContext {
+    bytes4 selector;
+    uint256 callStart;
+    uint256 callEnd;
+}
+
+function context() external view returns (TriggerContext memory);
+```
+
+This reverts outside an assertion function triggered by `registerFnCallTrigger`.
+
+### ERC20 Introspection
+
+#### `Erc20TransferData`
+
+Decoded ERC20 `Transfer` event data.
+
+```solidity
+struct Erc20TransferData {
+    address token_addr;
+    address from;
+    address to;
+    uint256 value;
 }
 ```
 
-## Next Steps
+#### `getErc20Transfers`
+
+Returns decoded ERC20 transfers for one token in a snapshot fork.
+
+```solidity
+function getErc20Transfers(
+    address token,
+    ForkId calldata fork
+) external view returns (Erc20TransferData[] memory transfers);
+```
+
+#### `getErc20TransfersForTokens`
+
+Returns decoded ERC20 transfers across multiple tokens in a snapshot fork.
+
+```solidity
+function getErc20TransfersForTokens(
+    address[] calldata tokens,
+    ForkId calldata fork
+) external view returns (Erc20TransferData[] memory transfers);
+```
+
+#### `changedErc20BalanceDeltas`
+
+Returns all transfer records involving a token in a snapshot fork.
+
+```solidity
+function changedErc20BalanceDeltas(
+    address token,
+    ForkId calldata fork
+) external view returns (Erc20TransferData[] memory deltas);
+```
+
+#### `reduceErc20BalanceDeltas`
+
+Aggregates transfers into net balance deltas per unique `(from, to)` pair.
+
+```solidity
+function reduceErc20BalanceDeltas(
+    address token,
+    ForkId calldata fork
+) external view returns (Erc20TransferData[] memory deltas);
+```
+
+### Mapping Tracing
+
+#### `changedMappingKeys`
+
+Returns canonical Solidity key encodings for mapping entries written during the transaction.
+
+```solidity
+function changedMappingKeys(
+    address target,
+    bytes32 baseSlot
+) external view returns (bytes[] memory keys);
+```
+
+This is a best-effort trace heuristic. Custom assembly or precomputed hashed slots can produce false negatives.
+
+#### `mappingValueDiff`
+
+Returns pre-transaction and post-transaction values for one mapping entry.
+
+```solidity
+function mappingValueDiff(
+    address target,
+    bytes32 baseSlot,
+    bytes calldata key,
+    uint256 fieldOffset
+) external view returns (bytes32 pre, bytes32 post, bool changed);
+```
+
+### Transaction Object
+
+#### `getTxObject`
+
+Returns data from the original assertion-triggering transaction.
+
+```solidity
+struct TxObject {
+    address from;
+    address to;
+    uint256 value;
+    uint64 chain_id;
+    uint64 gas_limit;
+    uint128 gas_price;
+    bytes input;
+}
+
+function getTxObject() external view returns (TxObject memory txObject);
+```
+
+### Protection Suite Helpers
+
+#### `forbidChangeForSlot`
+
+Checks that one adopter storage slot was not modified.
+
+```solidity
+function forbidChangeForSlot(
+    bytes32 slot
+) external returns (bool ok);
+```
+
+#### `forbidChangeForSlots`
+
+Checks that none of the listed adopter storage slots were modified.
+
+```solidity
+function forbidChangeForSlots(
+    bytes32[] calldata slots
+) external returns (bool ok);
+```
+
+#### `conserveBalance`
+
+Checks that an account's ERC20 balance is unchanged between two forks.
+
+```solidity
+function conserveBalance(
+    ForkId calldata fork0,
+    ForkId calldata fork1,
+    address token,
+    address account
+) external returns (bool);
+```
+
+#### `oracleSanity`
+
+Checks oracle price consistency across all fork points.
+
+```solidity
+function oracleSanity(
+    address target,
+    bytes calldata data,
+    uint256 bpsDeviation
+) external returns (bool);
+```
+
+#### `oracleSanityAt`
+
+Checks oracle price consistency between two specific forks.
+
+```solidity
+function oracleSanityAt(
+    address target,
+    bytes calldata data,
+    uint256 bpsDeviation,
+    ForkId calldata initialFork,
+    ForkId calldata currentFork
+) external returns (bool);
+```
+
+#### `assetsMatchSharePrice`
+
+Checks ERC4626 share price consistency across all fork points.
+
+```solidity
+function assetsMatchSharePrice(
+    address vault,
+    uint256 toleranceBps
+) external returns (bool);
+```
+
+#### `assetsMatchSharePriceAt`
+
+Checks ERC4626 share price consistency between two forks.
+
+```solidity
+function assetsMatchSharePriceAt(
+    address vault,
+    uint256 toleranceBps,
+    ForkId calldata fork0,
+    ForkId calldata fork1
+) external returns (bool);
+```
+
+### Circuit Breaker Context
+
+#### `outflowContext`
+
+Returns context for an assertion triggered by `watchCumulativeOutflow`.
+
+```solidity
+struct OutflowContext {
+    address token;
+    uint256 cumulativeOutflow;
+    uint256 absoluteOutflow;
+    uint256 currentBps;
+    uint256 tvlSnapshot;
+    uint256 windowStart;
+    uint256 windowEnd;
+}
+
+function outflowContext() external view returns (OutflowContext memory ctx);
+```
+
+#### `inflowContext`
+
+Returns context for an assertion triggered by `watchCumulativeInflow`.
+
+```solidity
+struct InflowContext {
+    address token;
+    uint256 cumulativeInflow;
+    uint256 absoluteInflow;
+    uint256 currentBps;
+    uint256 tvlSnapshot;
+    uint256 windowStart;
+    uint256 windowEnd;
+}
+
+function inflowContext() external view returns (InflowContext memory ctx);
+```
+
+### Math Helpers
+
+#### `mulDivDown`
+
+Computes `(x * y) / denominator`, rounded down, using 512-bit intermediates.
+
+```solidity
+function mulDivDown(
+    uint256 x,
+    uint256 y,
+    uint256 denominator
+) external pure returns (uint256 result);
+```
+
+#### `mulDivUp`
+
+Computes `(x * y) / denominator`, rounded up, using 512-bit intermediates.
+
+```solidity
+function mulDivUp(
+    uint256 x,
+    uint256 y,
+    uint256 denominator
+) external pure returns (uint256 result);
+```
+
+#### `normalizeDecimals`
+
+Scales an amount from one decimal base to another.
+
+```solidity
+function normalizeDecimals(
+    uint256 amount,
+    uint8 fromDecimals,
+    uint8 toDecimals
+) external pure returns (uint256 result);
+```
+
+#### `ratioGe`
+
+Compares two ratios with basis-point tolerance.
+
+```solidity
+function ratioGe(
+    uint256 num1,
+    uint256 den1,
+    uint256 num2,
+    uint256 den2,
+    uint256 toleranceBps
+) external pure returns (bool);
+```
+
+### Reshiram Trigger Registration
+
+Reshiram trigger registration functions are internal helpers on `Assertion`.
+
+#### `registerFnCallTrigger`
+
+Registers an assertion that fires once per matching adopter call. Use `ph.context()` inside the assertion to inspect the matched call context.
+
+```solidity
+function registerFnCallTrigger(
+    bytes4 fnSelector,
+    bytes4 triggerSelector
+) internal view;
+```
+
+#### `registerTxEndTrigger`
+
+Registers an assertion that fires once after the transaction completes.
+
+```solidity
+function registerTxEndTrigger(
+    bytes4 fnSelector
+) internal view;
+```
+
+#### `registerErc20ChangeTrigger`
+
+Registers an assertion that fires when a token's balances change.
+
+```solidity
+function registerErc20ChangeTrigger(
+    bytes4 fnSelector,
+    address token
+) internal view;
+```
+
+#### `watchCumulativeOutflow`
+
+Registers a circuit breaker trigger for cumulative ERC20 outflow from the assertion adopter.
+
+```solidity
+function watchCumulativeOutflow(
+    address token,
+    uint256 thresholdBps,
+    uint256 windowDuration,
+    bytes4 fnSelector
+) internal view;
+```
+
+`thresholdBps` is measured against the TVL snapshot taken at the start of the rolling window. `1000` is `10%`.
+
+#### `watchCumulativeInflow`
+
+Registers a circuit breaker trigger for cumulative ERC20 inflow into the assertion adopter.
+
+```solidity
+function watchCumulativeInflow(
+    address token,
+    uint256 thresholdBps,
+    uint256 windowDuration,
+    bytes4 fnSelector
+) internal view;
+```
+
+`thresholdBps` is measured against the TVL snapshot taken at the start of the rolling window. `1000` is `10%`.
+
+## Related Pages
 
 <CardGroup cols={2}>
-  <Card title="Full API Reference" icon="file-code" href="https://phylaxsystems.github.io/credible-std/index.html">
-    Autogenerated API documentation for credible-std
+  <Card title="Cheatcodes Overview" icon="book" href="./cheatcodes-overview">
+    Conceptual overview of cheatcodes
   </Card>
-  <Card title="Assertion Guide" icon="code" href="/credible/write-first-assertion">
-    Learn how to write assertions using cheatcodes
+  <Card title="Write Your First Assertion" icon="code" href="./write-first-assertion">
+    Tutorial for writing an assertion
   </Card>
-  <Card title="Use Case Mappings" icon="map" href="/credible/use-case-mappings/intro-use-case-mapping">
-    See practical examples of cheatcodes in action
+  <Card title="Use Case Mappings" icon="map" href="./use-case-mappings/intro-use-case-mapping">
+    Examples of assertion capabilities
   </Card>
-  <Card title="Assertions Book" icon="book-open" href="/assertions-book/assertions-book-intro">
-    Real-world assertion examples and implementations
-  </Card>
-  <Card title="Testing Assertions" icon="flask" href="/credible/testing-assertions">
-    Test your assertions locally
+  <Card title="Testing Assertions" icon="flask" href="./testing-assertions">
+    How to test assertions locally
   </Card>
 </CardGroup>
+
+## Deprecated Cheatcodes
+
+<Warning>
+Do not use these cheatcodes in new assertions. They mutate the active fork globally and are replaced by Reshiram's explicit `ForkId`-based `loadStateAt` API.
+</Warning>
+
+### `forkPreTx`
+
+Switches the active fork to the state before the assertion-triggering transaction.
+
+```solidity
+function forkPreTx() external;
+```
+
+Use `loadStateAt(..., PhEvm.ForkId({forkType: 0, callIndex: 0}))` instead.
+
+### `forkPostTx`
+
+Switches the active fork to the state after the assertion-triggering transaction.
+
+```solidity
+function forkPostTx() external;
+```
+
+Use `loadStateAt(..., PhEvm.ForkId({forkType: 1, callIndex: 0}))` instead.
+
+### `forkPreCall`
+
+Switches the active fork to the state before a specific call execution.
+
+```solidity
+function forkPreCall(uint256 id) external;
+```
+
+Use `loadStateAt(..., PhEvm.ForkId({forkType: 2, callIndex: id}))` instead.
+
+### `forkPostCall`
+
+Switches the active fork to the state after a specific call execution.
+
+```solidity
+function forkPostCall(uint256 id) external;
+```
+
+Use `loadStateAt(..., PhEvm.ForkId({forkType: 3, callIndex: id}))` instead.
+
+### `load(address, bytes32)`
+
+Loads a storage slot from an address on the current active fork.
+
+```solidity
+function load(
+    address target,
+    bytes32 slot
+) external view returns (bytes32 data);
+```
+
+Use `loadStateAt(target, slot, fork)` instead.

--- a/credible/cheatcodes-reference.mdx
+++ b/credible/cheatcodes-reference.mdx
@@ -797,23 +797,6 @@ function watchCumulativeInflow(
 
 `thresholdBps` is measured against the TVL snapshot taken at the start of the rolling window. `1000` is `10%`.
 
-## Related Pages
-
-<CardGroup cols={2}>
-  <Card title="Cheatcodes Overview" icon="book" href="./cheatcodes-overview">
-    Conceptual overview of cheatcodes
-  </Card>
-  <Card title="Write Your First Assertion" icon="code" href="./write-first-assertion">
-    Tutorial for writing an assertion
-  </Card>
-  <Card title="Use Case Mappings" icon="map" href="./use-case-mappings/intro-use-case-mapping">
-    Examples of assertion capabilities
-  </Card>
-  <Card title="Testing Assertions" icon="flask" href="./testing-assertions">
-    How to test assertions locally
-  </Card>
-</CardGroup>
-
 ## Deprecated Cheatcodes
 
 <Warning>
@@ -872,3 +855,20 @@ function load(
 ```
 
 Use `loadStateAt(target, slot, fork)` instead.
+
+## Related Pages
+
+<CardGroup cols={2}>
+  <Card title="Cheatcodes Overview" icon="book" href="./cheatcodes-overview">
+    Conceptual overview of cheatcodes
+  </Card>
+  <Card title="Write Your First Assertion" icon="code" href="./write-first-assertion">
+    Tutorial for writing an assertion
+  </Card>
+  <Card title="Use Case Mappings" icon="map" href="./use-case-mappings/intro-use-case-mapping">
+    Examples of assertion capabilities
+  </Card>
+  <Card title="Testing Assertions" icon="flask" href="./testing-assertions">
+    How to test assertions locally
+  </Card>
+</CardGroup>

--- a/credible/cli-reference.mdx
+++ b/credible/cli-reference.mdx
@@ -1,179 +1,288 @@
 ---
-title: 'pcl Reference'
-description: 'Reference documentation for all `pcl` commands, options, and parameters'
+title: 'pcl CLI Reference'
+description: 'Reference documentation for `pcl` commands, options, configuration, and environment variables'
 ---
+
+`pcl` is the Credible CLI for building, testing, verifying, deploying, and downloading Credible Layer assertions.
 
 <Note>
 New to `pcl`? Start with the [Quickstart Tutorial](/credible/pcl-quickstart) to learn the workflow.
 </Note>
 
-## Global Options
+## Version
+
+This reference matches `pcl 1.3.3`.
 
 ```bash
-Options:
-  -j, --json      Output in JSON format
-  -h, --help      Print help
-  -V, --version   Print version
+pcl 1.3.3
+Commit: 864b0db687c83c4010bc4ca3fee379607a19b094
+Build Timestamp: 2026-04-30T16:20:59.647643000Z
+Default Platform URL: https://app.phylax.systems
 ```
+
+## Syntax
+
+```bash
+pcl [OPTIONS] COMMAND
+```
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-j, --json` | Emit JSON output where supported |
+| `-h, --help` | Print help |
+| `-V, --version` | Print version |
 
 ## Commands
 
-Commands are listed in the order they are usually used in the assertion development workflow.
+| Command | Description |
+|---------|-------------|
+| [`pcl test`](#test) | Run tests using Phorge |
+| [`pcl apply`](#apply) | Preview and apply declarative deployment changes from `credible.toml` |
+| [`pcl auth`](#auth) | Authenticate the CLI with your Credible Layer Platform account |
+| [`pcl config`](#config) | Manage CLI configuration |
+| [`pcl build`](#build) | Build contracts using Phorge |
+| [`pcl verify`](#verify) | Verify assertions locally before deployment |
+| [`pcl download`](#download) | Download assertion source code for a protocol |
 
-### `auth`
+## `test`
 
-Manage authentication with your Phylax platform account.
-
-```bash
-Authenticate `pcl` with your Phylax platform account
-
-Usage: pcl auth [OPTIONS] <COMMAND>
-
-Commands:
-  login   Login to `pcl` using your wallet
-  logout  Logout from `pcl`
-  status  Check current authentication status
-  help    Print this message or the help of the given subcommand(s)
-
-Options:
-  -u, --auth-url <AUTH_URL>  Base URL for authentication service [env: PCL_AUTH_URL=] [default: https://app.phylax.systems]
-  -h, --help                 Print help
-```
-
-#### `auth login`
-
-Login to `pcl`. Opens a browser window where you can authenticate via wallet, email, Google, or GitHub.
-
-#### `auth logout`
-
-Logout from `pcl` and clear local authentication token.
-
-#### `auth status`
-
-Check current authentication status.
-
-### `test`
-
-Run tests for your assertions.
+Runs tests using Phorge.
 
 ```bash
-Run tests
-
-Usage: pcl test [OPTIONS] [PATH]
-
-Options:
-  -h, --help  Print help (see more with '--help')
-
-Common options:
-  -v, --verbosity...            Verbosity level of the log messages. Pass multiple times to increase verbosity (e.g. -v, -vv, -vvv)
-  -q, --quiet                   Do not print log messages
-      --match-path <GLOB>       Only run tests in source files matching the specified glob pattern
-      --match-test <REGEX>      Only run test functions matching the specified regex pattern
-      --match-contract <REGEX>  Only run tests in contracts matching the specified regex pattern
+pcl test [OPTIONS] [PATH]
 ```
+
+`[PATH]` is the contract file to test. It is a shortcut for `--match-path`.
+
+### Common `test` Options
+
+| Option | Description |
+|--------|-------------|
+| `-v, --verbosity...` | Increase log verbosity. Pass multiple times, such as `-vvv` |
+| `-q, --quiet` | Do not print log messages |
+| `--json` | Format log messages as JSON |
+| `--md` | Format log messages as Markdown |
+| `--color COLOR` | Set log color mode: `auto`, `always`, or `never` |
+| `-s, --suppress-successful-traces` | Show traces only for failures |
+| `--junit` | Output test results as a JUnit XML report |
+| `-l, --list` | List tests instead of running them |
+| `--summary` | Print a test summary table |
+| `--detailed` | Print a detailed test summary table |
+| `--gas-report` | Print a gas report |
+| `--fail-fast` | Stop after the first failure |
+| `--rerun` | Re-run recorded failures from the last run |
+| `-w, --watch [PATH...]` | Watch files or directories for changes |
+
+### Test Filtering
+
+| Option | Description |
+|--------|-------------|
+| `--match-test REGEX` | Only run test functions matching the regex |
+| `--no-match-test REGEX` | Exclude test functions matching the regex |
+| `--match-contract REGEX` | Only run tests in matching contracts |
+| `--no-match-contract REGEX` | Exclude tests in matching contracts |
+| `--match-path GLOB` | Only run tests in matching source files |
+| `--no-match-path GLOB` | Exclude tests in matching source files |
+| `--no-match-coverage REGEX` | Exclude matching files from coverage output |
+
+### EVM and Build Options
+
+`pcl test` supports many Forge-compatible EVM, fork, compiler, linker, cache, project, and watch options. Use `pcl test --help` for the complete option list.
 
 <Note>
-`pcl test` uses Forge underneath for test execution. Note that `pcl` uses an older version of Forge, so newer Forge features may not be available. The Forge version is periodically updated to include new features. See the [Forge test documentation](https://book.getfoundry.sh/reference/forge/forge-test) for all available options.
+`pcl test` uses Phorge for test execution. Some Forge options may differ from upstream Foundry behavior. Use `pcl test --help` as the authoritative option list for your installed `pcl` version.
 </Note>
 
-### `build`
+## `apply`
 
-Build contracts using [`phorge`](/credible/glossary#phorge).
+Previews and applies declarative deployment changes from `credible.toml`.
 
 ```bash
-Build contracts using `phorge`
-
-Usage: pcl build [OPTIONS]
-
-Options:
-      --root <ROOT>  Root directory of the project
-  -h, --help         Print help
+pcl apply [OPTIONS]
 ```
 
-### `apply`
+`pcl apply` reads [`credible.toml`](#credibletoml-configuration), builds and verifies referenced assertion contracts, previews release changes against the platform, and creates a release after confirmation.
 
-Preview and apply declarative deployment changes from `credible.toml`. This is the primary command for deploying assertions to the platform.
+### `apply` Options
 
-`pcl apply` reads your [`credible.toml`](#credibletoml-configuration) configuration, builds and compiles the referenced assertion contracts, and creates a release on the platform.
+| Option | Description |
+|--------|-------------|
+| `--root ROOT` | Project root directory. Default: `.` |
+| `-c, --config CONFIG` | Path to `credible.toml`, relative to root or absolute. Default: `assertions/credible.toml` |
+| `--json` | Emit machine-readable output for this command |
+| `--yes` | Apply without interactive confirmation |
+| `--auto-approve` | Alias for `--yes` |
+| `-u, --api-url API_URL` | Base URL for the platform API. Default: `https://app.phylax.systems` |
+| `-h, --help` | Print help |
+
+### `apply` Behavior
+
+- If `project_id` is omitted from `credible.toml`, `pcl apply` prompts you to select a project interactively.
+- If JSON output is enabled, `project_id` is required in `credible.toml`.
+- If there are no release changes, the command exits without creating a release.
+- If `--yes` is omitted, the command prompts for confirmation before applying changes.
+
+### `apply` Examples
 
 ```bash
-Preview and apply declarative deployment changes from credible.toml
-
-Usage: pcl apply [OPTIONS]
-
-Options:
-      --root <ROOT>      Project root directory [default: .]
-  -c, --config <CONFIG>  Path to credible.toml, relative to root or absolute [default: assertions/credible.toml]
-      --json             Emit machine-readable output
-      --yes              Apply without interactive confirmation
-  -u, --api-url <URL>    Base URL for the platform API [env: PCL_API_URL=] [default: https://app.phylax.systems]
-  -h, --help             Print help
-```
-
-**Examples:**
-
-```bash
-# Apply using default config location (assertions/credible.toml)
 pcl apply
-
-# Specify a project root directory
 pcl apply --root ./my-project
-
-# Use a custom config path
 pcl apply --root ./my-project -c path/to/credible.toml
-
-# Auto-approve without interactive confirmation
 pcl apply --yes
-
-# Output in JSON format for CI/CD
 pcl apply --json --yes
 ```
 
-<Note>
-By default, `pcl apply` looks for `credible.toml` at `assertions/credible.toml` relative to the project root. Use `-c` to override this path.
-</Note>
+## `auth`
 
-<Tip>
-If `project_id` is not set in your `credible.toml`, `pcl apply` will prompt you to select a project interactively. Set it in the config to skip this prompt, especially useful in CI/CD.
-</Tip>
-
-### `config`
-
-Manage your `pcl` configuration including authentication tokens and settings.
+Authenticates the CLI with your Credible Layer Platform account.
 
 ```bash
-Manage configuration
-
-Usage: pcl config <COMMAND>
-
-Commands:
-  show    Display the current configuration
-  delete  Delete the current configuration
-  help    Print this message or the help of the given subcommand(s)
-
-Options:
-  -h, --help  Print help
+pcl auth [OPTIONS] COMMAND
 ```
 
-#### `config show`
+### `auth` Commands
 
-Display the current configuration stored in `~/.config/pcl/config.toml`.
+| Command | Description |
+|---------|-------------|
+| `login` | Login to PCL |
+| `logout` | Logout from PCL |
+| `status` | Check current authentication status |
+| `help` | Print help |
 
-#### `config delete`
+### `auth` Options
 
-Delete the current configuration file.
+| Option | Description |
+|--------|-------------|
+| `-u, --auth-url AUTH_URL` | Base URL for the authentication service. Default: `https://app.phylax.systems` |
+| `-h, --help` | Print help |
+
+## `config`
+
+Manages CLI configuration.
+
+```bash
+pcl config COMMAND
+```
+
+### `config` Commands
+
+| Command | Description |
+|---------|-------------|
+| `show` | Display the current configuration |
+| `delete` | Delete the current configuration |
+| `help` | Print help |
+
+Configuration is stored in `~/.config/pcl/config.toml` by default and includes authentication tokens and identity.
+
+## `build`
+
+Builds contracts using Phorge.
+
+```bash
+pcl build [OPTIONS]
+```
+
+### `build` Options
+
+| Option | Description |
+|--------|-------------|
+| `--root ROOT` | Root directory of the project |
+| `-h, --help` | Print help |
+
+## `verify`
+
+Verifies assertions locally before deployment.
+
+```bash
+pcl verify [OPTIONS] [ASSERTION]
+```
+
+`[ASSERTION]` can be a contract name or `file:contract`. If omitted, `pcl verify` verifies all assertions from `credible.toml`.
+
+### `verify` Options
+
+| Option | Description |
+|--------|-------------|
+| `--root ROOT` | Project root directory. Default: `.` |
+| `-c, --config CONFIG` | Path to `credible.toml`, relative to root or absolute. Default: `assertions/credible.toml` |
+| `--args ARGS...` | Constructor arguments for the assertion |
+| `--json` | Emit machine-readable JSON output |
+| `-h, --help` | Print help |
+
+### `verify` Behavior
+
+- When `[ASSERTION]` is omitted, constructor arguments come from each assertion's `args` field in `credible.toml`.
+- `--args` can only be used when verifying a specific assertion.
+- Constructor arguments are ABI-encoded against the assertion contract constructor.
+- The command exits with code `1` if any assertion fails verification.
+
+### Verification Statuses
+
+| Status | Meaning |
+|--------|---------|
+| `success` | The assertion verified successfully |
+| `deployment_failure` | The assertion failed during deployment in the local verification environment |
+| `no_triggers` | The assertion did not expose any triggers |
+| `missing_assertion_spec` | The assertion is missing the required assertion specification |
+| `invalid_assertion_spec` | The assertion specification is invalid |
+
+### `verify` Examples
+
+```bash
+pcl verify
+pcl verify OwnableAssertion
+pcl verify assertions/src/OwnableAssertion.a.sol:OwnableAssertion
+pcl verify OwnableAssertion --args 0x75634113D6A2fbfF5e65151ce1572195bE1d001A
+pcl verify --json
+```
+
+## `download`
+
+Downloads assertion source code for a protocol.
+
+```bash
+pcl download [OPTIONS]
+```
+
+### `download` Options
+
+| Option | Description |
+|--------|-------------|
+| `--project-id PROJECT_ID` | Project UUID to download assertions from |
+| `-o, --output-dir OUTPUT_DIR` | Output directory for `.sol` files. Default: `PROJECT_NAME-assertions/` |
+| `--json` | Emit machine-readable output for this command |
+| `-u, --api-url API_URL` | Base URL for the platform API. Default: `https://app.phylax.systems` |
+| `-h, --help` | Print help |
+
+### `download` Behavior
+
+- `--project-id` is required.
+- The command requires authentication. Run `pcl auth login` first.
+- By default, files are written to a directory named after the project: `PROJECT_NAME-assertions/`.
+- Downloaded files use the pattern `CONTRACT_NAME_ASSERTION_ID_PREFIX.sol`.
+- Assertions without available source are skipped.
+
+### `download` Examples
+
+```bash
+pcl download --project-id 550e8400-e29b-41d4-a716-446655440000
+pcl download --project-id 550e8400-e29b-41d4-a716-446655440000 -o ./downloaded-assertions
+pcl download --project-id 550e8400-e29b-41d4-a716-446655440000 --json
+```
 
 ## `credible.toml` Configuration
 
-The `credible.toml` file defines your project's assertion deployment configuration. It maps contracts to their assertions in a declarative format.
+The `credible.toml` file defines assertion deployment configuration for `pcl apply` and `pcl verify`.
 
-**Default location:** `assertions/credible.toml` (relative to your project root)
+**Default location:** `assertions/credible.toml`, relative to the project root.
 
 ### Format
 
 ```toml
 environment = "production"
-project_id = "550e8400-e29b-41d4-a716-446655440000" # optional
+project_id = "550e8400-e29b-41d4-a716-446655440000"
 
 [contracts.my_contract]
 address = "0x1234567890abcdef1234567890abcdef12345678"
@@ -181,82 +290,58 @@ name = "MyContract"
 
 [[contracts.my_contract.assertions]]
 file = "assertions/src/MyAssertion.a.sol"
+args = ["0x75634113D6A2fbfF5e65151ce1572195bE1d001A", "42"]
 ```
 
-### Fields
+### Root Fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `environment` | string | Yes | Deployment environment name (e.g., `"production"`) |
-| `project_id` | UUID | No | Platform project ID. If omitted, you are prompted to select one interactively |
-| `contracts` | map | Yes | Named contract definitions (see below) |
+| `environment` | string | Yes | Deployment environment name, such as `"production"` |
+| `project_id` | UUID | No | Platform project ID. Required when `pcl apply` emits JSON output |
+| `contracts` | map | Yes | Named contract definitions |
 
-**Contract fields:**
+### Contract Fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `address` | string | Yes | Contract address on-chain |
 | `name` | string | Yes | Human-readable contract name |
-| `assertions` | array | Yes | List of assertions to apply to this contract |
+| `assertions` | array | Yes | Assertions to apply to this contract |
 
-**Assertion fields:**
+### Assertion Fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `file` | string | Yes | Path to assertion contract file (relative to project root) |
-| `args` | array | No | Constructor arguments for the assertion |
+| `file` | string | Yes | Assertion contract file path. Use `file.sol:ContractName` when the contract name cannot be inferred from the filename |
+| `args` | array or scalar | No | Constructor arguments for the assertion. Values are converted to strings before ABI encoding |
 
-### Example
+### Contract Name Inference
 
-```toml
-environment = "production"
+`pcl` infers assertion contract names from `file` in this order:
 
-[contracts.ownable]
-address = "0x75634113D6A2fbfF5e65151ce1572195bE1d001A"
-name = "Ownable"
+| `file` value | Inferred contract |
+|--------------|-------------------|
+| `assertions/src/MyAssertion.a.sol:ExplicitAssertion` | `ExplicitAssertion` |
+| `assertions/src/MyAssertion.a.sol` | `MyAssertion` |
+| `assertions/src/MyAssertion.sol` | `MyAssertion` |
 
-[[contracts.ownable.assertions]]
-file = "assertions/src/OwnableAssertion.a.sol"
+### Validation
 
-[contracts.phylock]
-address = "0xD452d2C8602322a46DFf0936fD6426BDC08358bf"
-name = "PhyLock"
-
-[[contracts.phylock.assertions]]
-file = "assertions/src/PhyLockAssertion.a.sol"
-```
-
-<Note>
-Each contract address must be unique within the configuration. `pcl apply` validates this and returns an error if duplicates are found.
-</Note>
+- Contract addresses must be unique within the file.
+- `pcl verify` returns an error if `credible.toml` contains no assertions.
+- `pcl apply --json` returns an error if `project_id` is missing.
 
 ## Environment Variables
 
-### `PCL_AUTH_URL`
-
-Base URL for authentication service. Default: `https://app.phylax.systems`
-
-```bash
-export PCL_AUTH_URL=https://custom-auth-url.com
-pcl auth login
-```
-
-### `PCL_API_URL`
-
-Base URL for the [Phylax platform](https://app.phylax.systems) API. Default: `https://app.phylax.systems`
-
-```bash
-export PCL_API_URL=https://custom-api-url.com
-pcl apply
-```
+| Variable | Used by | Description | Default |
+|----------|---------|-------------|---------|
+| `PCL_AUTH_URL` | `pcl auth` | Base URL for the authentication service | `https://app.phylax.systems` |
+| `PCL_API_URL` | `pcl apply`, `pcl download` | Base URL for the platform API | `https://app.phylax.systems` |
 
 ## Configuration File
 
-Configuration is stored in `~/.config/pcl/config.toml` and includes:
-
-- Authentication tokens and identity
-
-You can view the configuration with `pcl config show` or delete it with `pcl config delete`.
+`pcl` stores CLI configuration in `~/.config/pcl/config.toml` by default. Use `pcl config show` to view the current configuration and `pcl config delete` to delete it.
 
 ## Next Steps
 

--- a/credible/credible-install.mdx
+++ b/credible/credible-install.mdx
@@ -89,7 +89,7 @@ You should see the version number of the installed `pcl` CLI.
 
 ## Installing the `credible-std` Library
 
-If you're looking to add the `credible-std` library to your existing project for writing assertions, see the [credible-std Library Overview](/credible/credible-std-overview) for installation instructions.
+If you're looking to add the `credible-std` library to your existing project for writing assertions, see the [credible-std Library Overview](/credible/credible-std-overview) for the package name, stable dependency, and remapping reference.
 
 ## Next Steps
 

--- a/credible/credible-layer-overview.mdx
+++ b/credible/credible-layer-overview.mdx
@@ -97,36 +97,38 @@ A simple assertion checking that pool rates don't change by more than 3x would h
 <Accordion title="View the assertion code">
 
 ```solidity
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
 contract BatchSwapDeltaAssertion is Assertion {
     uint256 constant MAX_RATE_CHANGE_MULTIPLIER = 3e18; // 3.0x
 
-    function assertionBatchSwapRateManipulation() external {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    function triggers() external view override {
+        registerFnCallTrigger(this.assertionBatchSwapRateManipulation.selector, IVault.batchSwap.selector);
+    }
+
+    function assertionBatchSwapRateManipulation() external view {
         address vault = ph.getAssertionAdopter();
-        PhEvm.CallInputs[] memory batchSwapCalls = ph.getAllCallInputs(
-            vault,
-            IVault.batchSwap.selector
-        );
+        PhEvm.TriggerContext memory ctx = ph.context();
 
-        for (uint256 i = 0; i < batchSwapCalls.length; i++) {
-            // Get affected pools from swap parameters
-            bytes32[] memory uniquePoolIds = _getUniquePoolIds(swaps);
+        // Get affected pools from swap parameters
+        bytes32[] memory uniquePoolIds = _getUniquePoolIds(swaps);
 
-            for (uint256 j = 0; j < uniquePoolIds.length; j++) {
-                (address poolAddress, ) = IVault(vault).getPool(uniquePoolIds[j]);
+        for (uint256 i = 0; i < uniquePoolIds.length; i++) {
+            (address poolAddress, ) = IVault(vault).getPool(uniquePoolIds[i]);
+            PhEvm.ForkId memory preCall = PhEvm.ForkId({forkType: 2, callIndex: ctx.callStart});
+            PhEvm.ForkId memory postCall = PhEvm.ForkId({forkType: 3, callIndex: ctx.callEnd});
 
-                // Check rate before and after the swap
-                ph.forkPreCall(callInput.id);
-                uint256 preRate = IRateProvider(poolAddress).getRate();
+            uint256 preRate = uint256(ph.loadStateAt(poolAddress, RATE_SLOT, preCall));
+            uint256 postRate = uint256(ph.loadStateAt(poolAddress, RATE_SLOT, postCall));
 
-                ph.forkPostCall(callInput.id);
-                uint256 postRate = IRateProvider(poolAddress).getRate();
-
-                // Revert if rate changed by more than 3x
-                require(
-                    (postRate * 1e18) / preRate <= MAX_RATE_CHANGE_MULTIPLIER,
-                    "BatchSwap: Extreme pool rate manipulation detected"
-                );
-            }
+            require(
+                (postRate * 1e18) / preRate <= MAX_RATE_CHANGE_MULTIPLIER,
+                "BatchSwap: Extreme pool rate manipulation detected"
+            );
         }
     }
 }

--- a/credible/credible-std-overview.mdx
+++ b/credible/credible-std-overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "credible-std Library"
-description: "Install credible-std and understand its assertion helper functions"
+description: "Reference for credible-std contracts, helpers, specs, and testing utilities"
 ---
 
 `credible-std` is the Solidity standard library for writing, testing, and backtesting Credible Layer assertions. It provides the base assertion contract, the `ph` interface for PhEVM cheatcodes, trigger registration helpers, snapshot-read helpers, typed state-change helpers, and Forge test utilities.
@@ -11,31 +11,18 @@ For individual cheatcode signatures, see the [Cheatcodes API Reference](./cheatc
 As of May 6, 2026, the latest `credible-std` exposes Reshiram helpers, but the v2 Reshiram spec is not live on Linea mainnet. Use Reshiram-only helpers for local or development workflows until Linea mainnet supports the spec.
 </Warning>
 
-## Installation
+## Package and Configuration
 
-<Note>
-`credible-std` is a Foundry library. Install [Foundry](https://book.getfoundry.sh/getting-started/installation) before adding it to a Solidity project.
-</Note>
+`credible-std` is distributed as a Foundry library.
 
-Install the latest stable release:
+| Item | Value |
+| --- | --- |
+| Repository | `phylaxsystems/credible-std` |
+| Stable dependency | `phylaxsystems/credible-std@0.4.0` |
+| Development dependency | `phylaxsystems/credible-std` |
+| Foundry remapping | `credible-std/=lib/credible-std/src/` |
 
-```bash
-forge install phylaxsystems/credible-std@0.4.0
-```
-
-Install the latest development version from the default branch:
-
-```bash
-forge install phylaxsystems/credible-std
-```
-
-Add the remapping to `remappings.txt`:
-
-```bash
-credible-std/=lib/credible-std/src/
-```
-
-If you use backtesting helpers, add a backtesting profile to `foundry.toml`:
+Backtesting helpers require `ffi = true` in the relevant Foundry profile:
 
 ```toml
 [profile.backtesting]
@@ -46,33 +33,6 @@ ffi = true
 gas_limit = 100000000
 test = "test"
 ```
-
-## Verify the Install
-
-Create a minimal assertion that imports `Assertion`:
-
-```solidity
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
-
-import {Assertion} from "credible-std/Assertion.sol";
-
-contract TestAssertion is Assertion {
-    constructor() {
-        registerAssertionSpec(AssertionSpec.Reshiram);
-    }
-
-    function triggers() external view override {}
-}
-```
-
-Run a build:
-
-```bash
-forge build
-```
-
-If the import resolves and the contract compiles, the library and remapping are configured.
 
 ## Core Contracts
 
@@ -233,34 +193,21 @@ Available specs:
 | `Reshiram` | Newer precompile set with explicit snapshot access and legacy-only fork-switching selectors disabled. |
 | `Experimental` | Unrestricted access to all available precompiles. May include untested or dangerous behavior. |
 
-## Testing Helpers
+## Testing Contracts
 
-Use `CredibleTest` in Forge tests to register an assertion against a target contract:
+`CredibleTest` is the base contract for local Forge tests. It exposes `cl.assertion(...)`, which registers an assertion against a target contract for the next transaction in a test.
 
 ```solidity
-import {CredibleTest} from "credible-std/CredibleTest.sol";
-import {Test} from "forge-std/Test.sol";
-
-contract MyAssertionTest is CredibleTest, Test {
-    function testAssertion() public {
-        cl.assertion({
-            adopter: address(target),
-            createData: type(MyAssertion).creationCode,
-            fnSelector: MyAssertion.checkInvariant.selector
-        });
-
-        target.doSomething();
-    }
+interface VmEx {
+    function assertion(
+        address adopter,
+        bytes calldata createData,
+        bytes4 fnSelector
+    ) external;
 }
 ```
 
-Run assertion tests with:
-
-```bash
-pcl test
-```
-
-Use `CredibleTestWithBacktesting` when you need historical transaction replay. Backtesting requires `ffi = true`, and the helper looks for `credible-std/scripts/backtesting/transaction_fetcher.sh`. Set `CREDIBLE_STD_PATH` if the script is not in a standard dependency location.
+`CredibleTestWithBacktesting` extends the local test base for historical transaction replay. It looks for `credible-std/scripts/backtesting/transaction_fetcher.sh`; `CREDIBLE_STD_PATH` overrides the default dependency lookup path.
 
 ## Related Pages
 

--- a/credible/credible-std-overview.mdx
+++ b/credible/credible-std-overview.mdx
@@ -135,8 +135,8 @@ Reshiram assertions should prefer explicit snapshot IDs over deprecated fork-swi
 Construct `ForkId` values explicitly:
 
 ```solidity
-PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
-PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+PhEvm.ForkId memory preTx = _preTx();
+PhEvm.ForkId memory postTx = _postTx();
 PhEvm.ForkId memory preCall = PhEvm.ForkId({forkType: 2, callIndex: callId});
 PhEvm.ForkId memory postCall = PhEvm.ForkId({forkType: 3, callIndex: callId});
 ```

--- a/credible/credible-std-overview.mdx
+++ b/credible/credible-std-overview.mdx
@@ -1,45 +1,55 @@
 ---
 title: "credible-std Library"
-description: "Overview of the Phylax credible-std Library"
+description: "Install credible-std and understand its assertion helper functions"
 ---
 
-`credible-std` is the standard library for implementing assertions in the Credible Layer. It provides the core contracts and interfaces needed to create and manage assertions for smart contract security monitoring.
+`credible-std` is the Solidity standard library for writing, testing, and backtesting Credible Layer assertions. It provides the base assertion contract, the `ph` interface for PhEVM cheatcodes, trigger registration helpers, snapshot-read helpers, typed state-change helpers, and Forge test utilities.
 
-You can find the repository on [GitHub](https://github.com/phylaxsystems/credible-std) and the [full API reference](https://phylaxsystems.github.io/credible-std/index.html).
+For individual cheatcode signatures, see the [Cheatcodes API Reference](./cheatcodes-reference). For local assertion tests, see [Testing Assertions](./testing-assertions).
+
+<Warning>
+As of May 6, 2026, the latest `credible-std` exposes Reshiram helpers, but the v2 Reshiram spec is not live on Linea mainnet. Use Reshiram-only helpers for local or development workflows until Linea mainnet supports the spec.
+</Warning>
 
 ## Installation
 
 <Note>
-`credible-std` requires [Foundry](https://book.getfoundry.sh/getting-started/installation) to be installed on your system.
+`credible-std` is a Foundry library. Install [Foundry](https://book.getfoundry.sh/getting-started/installation) before adding it to a Solidity project.
 </Note>
 
-### Option 1: Using Forge Install (Recommended)
-
-The easiest way to install `credible-std` is to use `forge install`:
+Install the latest stable release:
 
 ```bash
-forge install credible-std=https://github.com/phylaxsystems/credible-std/
+forge install phylaxsystems/credible-std@0.4.0
 ```
 
-### Option 2: Using Git Submodules
-
-For more control over the dependency, you can add it as a git submodule:
+Install the latest development version from the default branch:
 
 ```bash
-git submodule add https://github.com/phylaxsystems/credible-std.git lib/credible-std
+forge install phylaxsystems/credible-std
 ```
 
-### Setting Up Remappings
-
-After installation, add the following to your `remappings.txt` file:
+Add the remapping to `remappings.txt`:
 
 ```bash
 credible-std/=lib/credible-std/src/
 ```
 
-### Verifying Installation
+If you use backtesting helpers, add a backtesting profile to `foundry.toml`:
 
-To verify that `credible-std` is properly installed, create a simple test file:
+```toml
+[profile.backtesting]
+src = "src"
+out = "out"
+libs = ["lib"]
+ffi = true
+gas_limit = 100000000
+test = "test"
+```
+
+## Verify the Install
+
+Create a minimal assertion that imports `Assertion`:
 
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -48,76 +58,223 @@ pragma solidity ^0.8.13;
 import {Assertion} from "credible-std/Assertion.sol";
 
 contract TestAssertion is Assertion {
-    function triggers() external view override {
-        // Empty for testing
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
+    function triggers() external view override {}
+}
+```
+
+Run a build:
+
+```bash
+forge build
+```
+
+If the import resolves and the contract compiles, the library and remapping are configured.
+
+## Core Contracts
+
+| Contract | Purpose |
+| --- | --- |
+| `Assertion.sol` | Base contract for assertions. Inherits `ForkUtils` and `StateChanges`, exposes trigger helpers, fork ID constructors, call matching helpers, and assertion spec registration. |
+| `Credible.sol` | Provides the inherited `ph` handle for calling the PhEVM precompile. |
+| `PhEvm.sol` | Interface for PhEVM cheatcodes, including logs, call inputs, snapshot reads, mapping tracing, ERC20 transfer data, and protection-suite helpers. |
+| `TriggerRecorder.sol` | Interface used by `Assertion` to register assertion triggers. |
+| `SpecRecorder.sol` | Defines `AssertionSpec` and records whether an assertion uses `Legacy`, `Reshiram`, or `Experimental` precompile access. |
+| `StateChanges.sol` | Typed helpers for legacy state-change arrays. |
+| `ForkUtils.sol` | Helper functions for Reshiram-style snapshot reads and ERC20 balance delta workflows. |
+| `CredibleTest.sol` | Forge test base that exposes `cl.assertion(...)`. |
+| `CredibleTestWithBacktesting.sol` | Test base for replaying historical transactions against assertions. |
+
+## Assertion Helpers
+
+`Assertion.sol` provides internal helpers for registering when assertion functions run.
+
+### Legacy Trigger Helpers
+
+Use these helpers for the launch-era trigger surface:
+
+```solidity
+function registerCallTrigger(bytes4 fnSelector) internal view;
+function registerCallTrigger(bytes4 fnSelector, bytes4 triggerSelector) internal view;
+function registerStorageChangeTrigger(bytes4 fnSelector) internal view;
+function registerStorageChangeTrigger(bytes4 fnSelector, bytes32 slot) internal view;
+function registerBalanceChangeTrigger(bytes4 fnSelector) internal view;
+```
+
+### Reshiram Trigger Helpers
+
+Use these helpers for newer trigger types:
+
+```solidity
+function registerFnCallTrigger(bytes4 fnSelector, bytes4 triggerSelector) internal view;
+function registerTxEndTrigger(bytes4 fnSelector) internal view;
+function registerErc20ChangeTrigger(bytes4 fnSelector, address token) internal view;
+function watchCumulativeOutflow(
+    address token,
+    uint256 thresholdBps,
+    uint256 windowDuration,
+    bytes4 fnSelector
+) internal view;
+function watchCumulativeInflow(
+    address token,
+    uint256 thresholdBps,
+    uint256 windowDuration,
+    bytes4 fnSelector
+) internal view;
+```
+
+`registerFnCallTrigger` pairs with `ph.context()` so an assertion can inspect the matched call's selector and call range.
+
+## Fork and Snapshot Helpers
+
+Reshiram assertions should prefer explicit snapshot IDs over deprecated fork-switching cheatcodes.
+
+Construct `ForkId` values explicitly:
+
+```solidity
+PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
+PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+PhEvm.ForkId memory preCall = PhEvm.ForkId({forkType: 2, callIndex: callId});
+PhEvm.ForkId memory postCall = PhEvm.ForkId({forkType: 3, callIndex: callId});
+```
+
+Use `ph.loadStateAt` to read storage at those snapshots:
+
+```solidity
+function loadStateAt(bytes32 slot, PhEvm.ForkId calldata fork)
+    external view returns (bytes32 value);
+
+function loadStateAt(address target, bytes32 slot, PhEvm.ForkId calldata fork)
+    external view returns (bytes32 value);
+```
+
+For packed storage or mappings, calculate the exact slot before calling `loadStateAt`.
+
+## ERC20 Delta Helpers
+
+`ForkUtils.sol` also includes ERC20 transfer-delta helpers:
+
+```solidity
+function _reducedErc20BalanceDeltasAt(address token, PhEvm.ForkId memory fork)
+    internal view returns (PhEvm.Erc20TransferData[] memory deltas);
+
+function _transferredValueAt(address token, address from, address to, PhEvm.ForkId memory fork)
+    internal view returns (uint256 value);
+
+function _consumedBetween(uint256 beforeValue, uint256 afterValue)
+    internal pure returns (uint256 consumed);
+```
+
+Use these helpers when an assertion needs to reason about ERC20 flows within a selected transaction or call snapshot.
+
+## State Change Helpers
+
+`StateChanges.sol` converts `ph.getStateChanges(...)` from `bytes32[]` into typed arrays:
+
+```solidity
+function getStateChangesUint(address contractAddress, bytes32 slot)
+    internal view returns (uint256[] memory);
+
+function getStateChangesAddress(address contractAddress, bytes32 slot)
+    internal view returns (address[] memory);
+
+function getStateChangesBool(address contractAddress, bytes32 slot)
+    internal view returns (bool[] memory);
+
+function getStateChangesBytes32(address contractAddress, bytes32 slot)
+    internal view returns (bytes32[] memory);
+```
+
+Each helper also has overloads for mapping keys and mapping keys with slot offsets:
+
+```solidity
+function getStateChangesUint(address contractAddress, bytes32 slot, uint256 key)
+    internal view returns (uint256[] memory);
+
+function getStateChangesUint(address contractAddress, bytes32 slot, uint256 key, uint256 slotOffset)
+    internal view returns (uint256[] memory);
+```
+
+The same overload pattern exists for `Address`, `Bool`, and `Bytes32`.
+
+## Call Matching Helpers
+
+`Assertion.sol` includes helpers for querying successful calls through the Reshiram call-matching precompile:
+
+```solidity
+function _successOnlyFilter() internal pure returns (PhEvm.CallFilter memory filter);
+
+function _matchingCalls(address target, bytes4 selector, uint256 limit)
+    internal view returns (PhEvm.TriggerCall[] memory);
+```
+
+Use `_matchingCalls` when an assertion needs a bounded list of successful calls to a target selector.
+
+## Assertion Spec Helper
+
+Register the desired assertion spec in the constructor:
+
+```solidity
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
+constructor() {
+    registerAssertionSpec(AssertionSpec.Reshiram);
+}
+```
+
+Available specs:
+
+| Spec | Meaning |
+| --- | --- |
+| `Legacy` | Standard launch precompile set. |
+| `Reshiram` | Newer precompile set with explicit snapshot access and legacy-only fork-switching selectors disabled. |
+| `Experimental` | Unrestricted access to all available precompiles. May include untested or dangerous behavior. |
+
+## Testing Helpers
+
+Use `CredibleTest` in Forge tests to register an assertion against a target contract:
+
+```solidity
+import {CredibleTest} from "credible-std/CredibleTest.sol";
+import {Test} from "forge-std/Test.sol";
+
+contract MyAssertionTest is CredibleTest, Test {
+    function testAssertion() public {
+        cl.assertion({
+            adopter: address(target),
+            createData: type(MyAssertion).creationCode,
+            fnSelector: MyAssertion.checkInvariant.selector
+        });
+
+        target.doSomething();
     }
 }
 ```
 
-If this compiles without errors, `credible-std` is properly installed and configured.
+Run assertion tests with:
 
-## Key Components
+```bash
+pcl test
+```
 
-The `credible-std` library provides several essential components for implementing assertions:
+Use `CredibleTestWithBacktesting` when you need historical transaction replay. Backtesting requires `ffi = true`, and the helper looks for `credible-std/scripts/backtesting/transaction_fetcher.sh`. Set `CREDIBLE_STD_PATH` if the script is not in a standard dependency location.
 
-### Core Contracts
+## Related Pages
 
-- `Credible.sol`: Base contract that provides access to the PhEvm precompile for assertion validation
-- `Assertion.sol`: Abstract contract for implementing assertions with trigger registration and validation logic
-- `StateChanges.sol`: Utilities for tracking and validating contract state changes with type-safe conversions
-- `TriggerRecorder.sol`: Manages assertion triggers for function calls, storage changes, and balance changes
-- `PhEvm.sol`: Interface for the PhEvm precompile that enables assertion validation
-- `CredibleTest.sol`: Testing utilities for assertion development and validation
-
-### Features
-
-1. **Trigger System**
-   - Register triggers for function calls, storage changes, and balance changes
-   - Monitor specific contract behaviors
-   - Support for multiple trigger types
-
-2. **State Change Tracking**
-   - Type-safe utilities for monitoring contract state changes
-   - Built-in conversion helpers
-   - Pre and post transaction state comparison
-   - Call stack level inspection of state changes
-   - Access to intermediate state during transaction execution
-   - Direct storage slot inspection and loading
-
-3. **Advanced Forking Capabilities**
-   - Fork to pre/post transaction states
-   - Fork to specific call execution points
-   - Granular state inspection at any call level
-
-4. **Comprehensive Call Tracing**
-   - Get all call inputs or filter by call type (CALL, STATICCALL, DELEGATECALL, CALLCODE)
-   - Avoid double-counting issues with proxy contracts
-   - Detailed call information including gas limits, values, and execution addresses
-   - Transaction log retrieval for assertion logic
-
-5. **Testing Framework**
-   - Testing utilities for assertion development and validation
-   - Integration with Forge testing framework
-
-6. **Debugging Tools**
-   - Console logging for assertion debugging
-
-For a detailed overview of currently supported use cases and examples, see our [Use Case Mappings](/credible/use-case-mappings/intro-use-case-mapping).
-
-## Solidity Integration
-
-`credible-std` is written in Solidity, making it seamlessly integrated with your existing smart contract development workflow. This means:
-
-- No context switching or learning new languages
-- Direct access to all Solidity features and tooling
-- Familiar development experience
-- Easy integration with existing contracts
-- Full compatibility with Foundry testing framework
-
-## Getting Started
-
-For installation and setup instructions, see the [PCL Quickstart Guide](/credible/pcl-quickstart).
-
----
-
-Missing a feature or cheatcode? Please [open an issue](https://github.com/phylaxsystems/credible-std/issues/new) with your feature request.
+<CardGroup cols={2}>
+  <Card title="Cheatcodes API Reference" icon="book" href="./cheatcodes-reference">
+    Full PhEVM cheatcode signatures
+  </Card>
+  <Card title="Testing Assertions" icon="flask" href="./testing-assertions">
+    How to test assertions locally
+  </Card>
+  <Card title="Backtesting Reference" icon="clock-rotate-left" href="./backtesting-reference">
+    Backtesting configuration and behavior
+  </Card>
+  <Card title="Write Your First Assertion" icon="code" href="./write-first-assertion">
+    Build a first assertion with credible-std
+  </Card>
+</CardGroup>

--- a/credible/development-effort.mdx
+++ b/credible/development-effort.mdx
@@ -20,7 +20,7 @@ Development effort depends on whether invariants are already defined for your pr
 When invariants exist, writing assertions is similar to writing Forge invariant tests:
 
 - **Workflow**: Write Solidity, test with `pcl test`(fork of `forge`), deploy via the [platform](https://app.phylax.systems)
-- **Learning curve**: A small set of [cheatcodes](/credible/cheatcodes-overview) for state comparison (`ph.forkPreTx()`, `ph.forkPostTx()`, etc.)
+- **Learning curve**: A small set of [cheatcodes](/credible/cheatcodes-overview) for snapshot reads (`PhEvm.ForkId`, `ph.loadStateAt`, etc.)
 - **Familiarity**: Developers who write Forge tests can write assertions
 
 ### Invariants Not Defined

--- a/credible/execution-model.mdx
+++ b/credible/execution-model.mdx
@@ -138,8 +138,8 @@ The `fnSelector` parameter specifies which assertion function to run, but trigge
 ```solidity
 // In assertion contract
 function triggers() external view override {
-    registerCallTrigger(this.assertDeposit.selector, Protocol.deposit.selector);
-    registerCallTrigger(this.assertWithdraw.selector, Protocol.withdraw.selector);
+    registerFnCallTrigger(this.assertDeposit.selector, Protocol.deposit.selector);
+    registerFnCallTrigger(this.assertWithdraw.selector, Protocol.withdraw.selector);
 }
 ```
 
@@ -172,4 +172,3 @@ To verify triggers work correctly with real transactions, use [backtesting](/cre
     Common errors
   </Card>
 </CardGroup>
-

--- a/credible/invariant-to-assertion.mdx
+++ b/credible/invariant-to-assertion.mdx
@@ -107,9 +107,9 @@ We register a trigger for each:
 
 ```solidity
 function triggers() external view override {
-    registerCallTrigger(this.assertionBatchSharePriceInvariant.selector, IEVC.batch.selector);
-    registerCallTrigger(this.assertionCallSharePriceInvariant.selector, IEVC.call.selector);
-    registerCallTrigger(this.assertionControlCollateralSharePriceInvariant.selector, IEVC.controlCollateral.selector);
+    registerFnCallTrigger(this.assertionBatchSharePriceInvariant.selector, IEVC.batch.selector);
+    registerFnCallTrigger(this.assertionCallSharePriceInvariant.selector, IEVC.call.selector);
+    registerFnCallTrigger(this.assertionControlCollateralSharePriceInvariant.selector, IEVC.controlCollateral.selector);
 }
 ```
 
@@ -149,17 +149,15 @@ Cheatcodes used:
 The core logic compares share prices before and after the transaction:
 
 ```solidity
-function validateVaultSharePriceInvariant(address vault) internal {
+function validateVaultSharePriceInvariant(address vault) internal view {
     // Skip non-contract addresses
     if (vault.code.length == 0) return;
-    
-    // Get share price BEFORE transaction
-    ph.forkPreTx();
-    uint256 preSharePrice = getSharePrice(vault);
-    
-    // Get share price AFTER transaction
-    ph.forkPostTx();
-    uint256 postSharePrice = getSharePrice(vault);
+
+    PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
+    PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+
+    uint256 preSharePrice = getSharePriceAt(vault, preTx);
+    uint256 postSharePrice = getSharePriceAt(vault, postTx);
     
     // Check the invariant
     if (postSharePrice < preSharePrice) {
@@ -172,9 +170,9 @@ function validateVaultSharePriceInvariant(address vault) internal {
     }
 }
 
-function getSharePrice(address vault) internal view returns (uint256) {
-    uint256 totalAssets = IERC4626(vault).totalAssets();
-    uint256 totalSupply = IERC4626(vault).totalSupply();
+function getSharePriceAt(address vault, PhEvm.ForkId memory fork) internal view returns (uint256) {
+    uint256 totalAssets = uint256(ph.loadStateAt(vault, TOTAL_ASSETS_SLOT, fork));
+    uint256 totalSupply = uint256(ph.loadStateAt(vault, TOTAL_SUPPLY_SLOT, fork));
     
     if (totalSupply > 0) {
         return (totalAssets * 1e18) / totalSupply;
@@ -184,8 +182,8 @@ function getSharePrice(address vault) internal view returns (uint256) {
 ```
 
 Cheatcodes used:
-- [`ph.forkPreTx()`](/credible/cheatcodes-reference#forkpretx): Switch to blockchain state before the transaction
-- [`ph.forkPostTx()`](/credible/cheatcodes-reference#forkposttx): Switch to blockchain state after the transaction
+- [`PhEvm.ForkId`](/credible/cheatcodes-reference#forkid): Identifies the pre-transaction and post-transaction snapshots
+- [`ph.loadStateAt()`](/credible/cheatcodes-reference#loadstateat): Reads a storage slot at a specific snapshot
 
 ### Part C: Detect Bad Debt Socialization
 
@@ -373,4 +371,3 @@ The complete example from this guide is available in our fork of the [EVC reposi
     Learn about trigger types and optimization
   </Card>
 </CardGroup>
-

--- a/credible/invariant-to-assertion.mdx
+++ b/credible/invariant-to-assertion.mdx
@@ -153,8 +153,8 @@ function validateVaultSharePriceInvariant(address vault) internal view {
     // Skip non-contract addresses
     if (vault.code.length == 0) return;
 
-    PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
-    PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+    PhEvm.ForkId memory preTx = _preTx();
+    PhEvm.ForkId memory postTx = _postTx();
 
     uint256 preSharePrice = getSharePriceAt(vault, preTx);
     uint256 postSharePrice = getSharePriceAt(vault, postTx);

--- a/credible/phevm.mdx
+++ b/credible/phevm.mdx
@@ -28,7 +28,7 @@ This enables assertions to compare values across different execution points, som
 
 PhEVM implements special precompiles called [cheatcodes](/credible/glossary#cheatcodes) that provide capabilities beyond standard EVM operations:
 
-- **State forking**: `forkPreTx()`, `forkPostTx()`, `forkPreCall()`, `forkPostCall()`
+- **Snapshot reads**: `loadStateAt` with explicit `ForkId` values for pre-transaction, post-transaction, pre-call, and post-call state
 - **Call introspection**: Access to call inputs, call traces, and execution context
 - **State change tracking**: Monitor storage slot modifications during execution
 - **Log access**: Retrieve transaction logs for validation
@@ -53,4 +53,3 @@ When the Assertion Enforcer receives a transaction for validation:
 4. **Result**: If any assertion reverts, the transaction is flagged as invalid
 
 For the complete validation flow, see [Assertion Enforcer](/credible/assertion-enforcer).
-

--- a/credible/testing-assertions.mdx
+++ b/credible/testing-assertions.mdx
@@ -187,7 +187,7 @@ When testing assertions, it can be difficult to trigger the conditions that woul
 2. Test by intentionally putting the protocol into an invalid state
 3. Verify that the assertion correctly catches the invalid state
 
-You can see examples of mock protocols in the [Assertion Examples](https://github.com/phylaxsystems/assertion-examples/tree/main/src) repository.
+You can see examples of mock protocols in the [Assertion Examples](https://github.com/phylaxsystems/credible-std/tree/master/src/protection) repository.
 
 ## Gas Limits
 

--- a/credible/testing-assertions.mdx
+++ b/credible/testing-assertions.mdx
@@ -187,7 +187,7 @@ When testing assertions, it can be difficult to trigger the conditions that woul
 2. Test by intentionally putting the protocol into an invalid state
 3. Verify that the assertion correctly catches the invalid state
 
-You can see examples of mock protocols in the [Assertion Examples](https://github.com/phylaxsystems/credible-std/tree/master/src/protection) repository.
+You can see examples of mock protocols in [credible-std Assertions Book examples](https://github.com/phylaxsystems/credible-std/tree/master/examples/assertions-book).
 
 ## Gas Limits
 

--- a/credible/triggers.mdx
+++ b/credible/triggers.mdx
@@ -22,37 +22,39 @@ This means:
 
 Different triggers provide different guarantees and should be chosen based on the specific invariant you're trying to enforce.
 
-### Storage Change Triggers
+### Function Call Triggers
 
-Storage change triggers are ideal when you need to monitor specific storage slots for changes, regardless of what function caused the change. This is useful when:
-
-- You want to check if a specific value is changed by any transaction
-- You don't care which functions trigger the changes
-- You need to catch all modifications to a particular storage slot
-
-**Example:**
-```solidity
-function triggers() external view override {
-    // Register trigger for changes to the owner storage slot
-    registerStorageChangeTrigger(this.assertOwnerChange.selector, bytes32(uint256(0))); // Assuming owner in slot 0
-}
-```
-
-### Call Input Triggers
-
-Call input triggers are useful when you need to monitor specific function calls. This is ideal when:
+Use `registerFnCallTrigger` when an assertion should run once for each successful call to a specific function. This is the preferred trigger for call-scoped checks because the assertion can read `ph.context()` and construct `PhEvm.ForkId({forkType: 2, callIndex: ctx.callStart})` / `PhEvm.ForkId({forkType: 3, callIndex: ctx.callEnd})` snapshots for the matched call.
 
 - You only want to run assertions when specific functions are called
 - You need to verify behavior of particular protocol operations
-- You want to check function parameters and their effects
+- You need call-scoped state reads or call metadata
 
 **Example:**
 ```solidity
 function triggers() external view override {
-    // Register our assertion function to be called when transferOwnership is called
-    registerCallTrigger(this.assertionOwnershipChange.selector, Ownable.transferOwnership.selector);
+    registerFnCallTrigger(this.assertionOwnershipChange.selector, Ownable.transferOwnership.selector);
 }
 ```
+
+### Transaction End Triggers
+
+Use `registerTxEndTrigger` when an assertion should run after any transaction that touches the protected contract. This is the preferred trigger for transaction-wide invariants where the relevant mutation can happen through multiple functions or indirect calls.
+
+- You need broad coverage across many entry points
+- You only need transaction-scoped `ForkId` snapshots
+- Function-specific triggers could miss an unexpected mutation path
+
+**Example:**
+```solidity
+function triggers() external view override {
+    registerTxEndTrigger(this.assertAccountingInvariant.selector);
+}
+```
+
+<Warning>
+Legacy `registerCallTrigger`, `registerStorageChangeTrigger`, and `registerBalanceChangeTrigger` helpers remain documented for older assertions, but new assertions should prefer `registerFnCallTrigger` and `registerTxEndTrigger`.
+</Warning>
 
 ## Best Practices
 
@@ -60,8 +62,8 @@ function triggers() external view override {
 
 Consider what state changes your assertion monitors:
 
-- **Use storage triggers** when monitoring specific storage slots
-- **Use call triggers** when monitoring specific function calls
+- **Use function call triggers** when monitoring specific functions
+- **Use transaction end triggers** for transaction-wide invariants
 - Consider the trade-off between coverage and efficiency
 
 ### Optimize for Performance

--- a/credible/troubleshooting.mdx
+++ b/credible/troubleshooting.mdx
@@ -148,7 +148,7 @@ Use `pcl test -vvv` to see detailed gas usage per operation.
 bytes32 data = vm.load(address, slot);
 
 // ✅ CORRECT
-bytes32 data = ph.loadStateAt(target, slot, PhEvm.ForkId({forkType: 1, callIndex: 0}));
+bytes32 data = ph.loadStateAt(target, slot, _postTx());
 ```
 
 The Phylax helper `ph` provides storage access, not the standard Forge `vm` cheatcode. New assertions should prefer Reshiram snapshot reads instead of legacy global fork switching.
@@ -361,8 +361,8 @@ import { console } from "credible-std/console.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 function assertionFunction() external {
-    uint256 preBalance = uint256(ph.loadStateAt(token, balanceSlot, PhEvm.ForkId({forkType: 0, callIndex: 0})));
-    uint256 postBalance = uint256(ph.loadStateAt(token, balanceSlot, PhEvm.ForkId({forkType: 1, callIndex: 0})));
+    uint256 preBalance = uint256(ph.loadStateAt(token, balanceSlot, _preTx()));
+    uint256 postBalance = uint256(ph.loadStateAt(token, balanceSlot, _postTx()));
     
     console.log(string.concat("Pre: ", Strings.toString(preBalance)));
     console.log(string.concat("Post: ", Strings.toString(postBalance)));

--- a/credible/troubleshooting.mdx
+++ b/credible/troubleshooting.mdx
@@ -11,7 +11,7 @@ This guide helps you diagnose and fix common errors when writing and testing ass
 |-------|--------------|-----------|
 | "Expected 1 assertion to be executed, but 0 were executed" | Transaction reverts or setup after `cl.assertion()` | Check trigger function, move setup before `cl.assertion()` |
 | OutOfGas error | Assertion exceeds 300k gas limit | Optimize loops, add early returns, fail fast |
-| `vm.load()` not available | Wrong cheatcode | Use `ph.load()` instead |
+| `vm.load()` not available | Wrong cheatcode | Use `ph.loadStateAt()` with a `ForkId` instead |
 | Function selector errors | Wrong selector or trigger not registered | Use `Protocol.functionName.selector`, check `triggers()` |
 | Call input double-counting | Using `getAllCallInputs()` | Use specific call type function |
 | Test contract address in error | Inline function call consumed `vm.prank()` | Store view function results before `vm.prank()` |
@@ -141,17 +141,17 @@ Use `pcl test -vvv` to see detailed gas usage per operation.
 
 **Error:** `vm.load()` is not available in assertions
 
-**Solution:** Use `ph.load()` instead:
+**Solution:** Use `ph.loadStateAt()` with an explicit `ForkId` instead:
 
 ```solidity
 // ❌ WRONG
 bytes32 data = vm.load(address, slot);
 
 // ✅ CORRECT
-bytes32 data = ph.load(address, slot);
+bytes32 data = ph.loadStateAt(target, slot, PhEvm.ForkId({forkType: 1, callIndex: 0}));
 ```
 
-The Phylax helper `ph` provides storage access, not the standard Forge `vm` cheatcode.
+The Phylax helper `ph` provides storage access, not the standard Forge `vm` cheatcode. New assertions should prefer Reshiram snapshot reads instead of legacy global fork switching.
 
 ### Constructor Limitations
 
@@ -185,10 +185,10 @@ function assertionFunction() external {
 
 ```solidity
 // ❌ WRONG
-registerCallTrigger(this.assertionFunction.selector, bytes4(0x12345678));
+registerFnCallTrigger(this.assertionFunction.selector, bytes4(0x12345678));
 
 // ✅ CORRECT
-registerCallTrigger(
+registerFnCallTrigger(
     this.assertionFunction.selector,
     Protocol.targetFunction.selector
 );
@@ -361,8 +361,8 @@ import { console } from "credible-std/console.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 function assertionFunction() external {
-    uint256 preBalance = uint256(ph.forkPreTx().load(token, balanceSlot));
-    uint256 postBalance = uint256(ph.forkPostTx().load(token, balanceSlot));
+    uint256 preBalance = uint256(ph.loadStateAt(token, balanceSlot, PhEvm.ForkId({forkType: 0, callIndex: 0})));
+    uint256 postBalance = uint256(ph.loadStateAt(token, balanceSlot, PhEvm.ForkId({forkType: 1, callIndex: 0})));
     
     console.log(string.concat("Pre: ", Strings.toString(preBalance)));
     console.log(string.concat("Post: ", Strings.toString(postBalance)));

--- a/credible/use-case-mappings/call-frame-context.mdx
+++ b/credible/use-case-mappings/call-frame-context.mdx
@@ -14,14 +14,16 @@ description: Gain fine-grained context about a call frame in order to improve th
 ### Required Cheatcodes
 
 - `getCallInputs(address aa, bytes4 signature)` - Gets call inputs with unique IDs
-- `forkPreCall(uint256 id)` - Forks to state at the start of a specific call
-- `forkPostCall(uint256 id)` - Forks to state after a specific call execution
+- `context()` - Gets the currently matched `onFnCall` trigger context
+- `loadStateAt(address target, bytes32 slot, ForkId fork)` - Reads storage at a call-scoped snapshot
 
 ### Example Implementation
 
 Protocol:
 
 ```solidity
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
 contract Protocol {
     mapping(address => uint256) public balances;
     uint256 public totalSupply;
@@ -43,42 +45,43 @@ Assertion:
 
 ```solidity
 contract CallFrameContextAssertion is Assertion {
-    function triggers() public view override {
-        registerCallTrigger(this.assertCallFrameContext.selector, Protocol.batchTransfer.selector);
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
-    function assertCallFrameContext() public {
+    function triggers() public view override {
+        registerFnCallTrigger(this.assertCallFrameContext.selector, Protocol.transfer.selector);
+    }
+
+    function assertCallFrameContext() public view {
         Protocol protocol = Protocol(ph.getAssertionAdopter());
-        // Get all transfer calls within the batchTransfer transaction
+        PhEvm.TriggerContext memory ctx = ph.context();
         PhEvm.CallInputs[] memory transferCalls = ph.getCallInputs(
             address(protocol),
             protocol.transfer.selector
         );
-
-        // Validate each transfer call individually
+        PhEvm.CallInputs memory transferCall;
         for (uint256 i = 0; i < transferCalls.length; i++) {
-            // Fork to state before this specific call
-            ph.forkPreCall(transferCalls[i].id);
-            address from = transferCalls[i].caller;
-            (address to, uint256 amount) = abi.decode(transferCalls[i].input, (address, uint256));
-            uint256 preFromBalance = protocol.balances(from);
-            uint256 preToBalance = protocol.balances(to);
-
-            // Fork to state after this specific call
-            ph.forkPostCall(transferCalls[i].id);
-            uint256 postFromBalance = protocol.balances(from);
-            uint256 postToBalance = protocol.balances(to);
-
-            // Verify the transfer was executed correctly for this call frame
-            require(
-                postFromBalance == preFromBalance - amount,
-                "From balance mismatch in call frame"
-            );
-            require(
-                postToBalance == preToBalance + amount,
-                "To balance mismatch in call frame"
-            );
+            if (transferCalls[i].id == ctx.callStart) {
+                transferCall = transferCalls[i];
+                break;
+            }
         }
+
+        address from = transferCall.caller;
+        (address to, uint256 amount) = abi.decode(transferCall.input, (address, uint256));
+        bytes32 fromBalanceSlot = keccak256(abi.encode(from, uint256(0)));
+        bytes32 toBalanceSlot = keccak256(abi.encode(to, uint256(0)));
+        PhEvm.ForkId memory preCall = PhEvm.ForkId({forkType: 2, callIndex: ctx.callStart});
+        PhEvm.ForkId memory postCall = PhEvm.ForkId({forkType: 3, callIndex: ctx.callEnd});
+
+        uint256 preFromBalance = uint256(ph.loadStateAt(address(protocol), fromBalanceSlot, preCall));
+        uint256 preToBalance = uint256(ph.loadStateAt(address(protocol), toBalanceSlot, preCall));
+        uint256 postFromBalance = uint256(ph.loadStateAt(address(protocol), fromBalanceSlot, postCall));
+        uint256 postToBalance = uint256(ph.loadStateAt(address(protocol), toBalanceSlot, postCall));
+
+        require(postFromBalance == preFromBalance - amount, "From balance mismatch in call frame");
+        require(postToBalance == preToBalance + amount, "To balance mismatch in call frame");
     }
 }
 ```
@@ -86,8 +89,9 @@ contract CallFrameContextAssertion is Assertion {
 ### Implementation Notes
 
 - **Call frame isolation:**
-    - Use `getCallInputs()` to retrieve all calls with their unique IDs
-    - Each call has an `id` field that can be used with `forkPreCall()` and `forkPostCall()`
+    - Use `registerFnCallTrigger()` to execute once for each matched call
+    - Use `ph.context()` to read the matched call's `callStart` and `callEnd`
+    - Construct `PhEvm.ForkId({forkType: 2, callIndex: ctx.callStart})` and `PhEvm.ForkId({forkType: 3, callIndex: ctx.callEnd})` for call-scoped snapshots
     - This allows validation at the individual function call level, not just transaction level
 
 - **Benefits over transaction-level assertions:**
@@ -97,8 +101,8 @@ contract CallFrameContextAssertion is Assertion {
     - Can catch issues that would be masked by transaction-level checks
 
 - **When to use call frame context vs transaction context:**
-    - Use `forkPreCall()`/`forkPostCall()` when you need to validate individual calls within a transaction
-    - Use `forkPreTx()`/`forkPostTx()` when you only need to compare overall transaction state
+    - Use call-scoped `ForkId` values when you need to validate individual calls within a transaction
+    - Use transaction-scoped `ForkId` values when you only need to compare overall transaction state
     - Call frame context is especially useful for batch operations, multi-step protocols, or when validating intermediate states
 
 ## Example Use Cases
@@ -116,4 +120,3 @@ contract CallFrameContextAssertion is Assertion {
 
 - [Function Call Inputs](/credible/use-case-mappings/function-call-inputs) - Similar but validates at transaction level
 - [State Changes](/credible/use-case-mappings/state-changes) - Track state changes across a transaction
-

--- a/credible/use-case-mappings/function-call-inputs.mdx
+++ b/credible/use-case-mappings/function-call-inputs.mdx
@@ -77,8 +77,8 @@ contract FunctionCallInputsAssertion is Assertion {
 
         for (uint256 i = 0; i < changedAddresses.length; i++) {
             bytes32 balanceSlot = keccak256(abi.encode(changedAddresses[i], uint256(0)));
-            PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
-            PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+            PhEvm.ForkId memory preTx = _preTx();
+            PhEvm.ForkId memory postTx = _postTx();
 
             preBalance = uint256(ph.loadStateAt(address(protocol), balanceSlot, preTx));
             uint256 postBalance = uint256(ph.loadStateAt(address(protocol), balanceSlot, postTx));

--- a/credible/use-case-mappings/function-call-inputs.mdx
+++ b/credible/use-case-mappings/function-call-inputs.mdx
@@ -14,14 +14,15 @@ description: Capture and verify function input parameters to validate that the r
 ### Required Cheatcodes
 
 - `getCallInputs(address aa, bytes4 signature)`
-- `forkPreTx()`
-- `forkPostTx()`
+- `loadStateAt(address target, bytes32 slot, ForkId fork)`
 
 ### Example Implementation
 
 Protocol:
 
 ```solidity
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
 contract Protocol {
     mapping(address => uint256) public balances;
 
@@ -40,14 +41,18 @@ Assertion:
 
 ```solidity
 contract FunctionCallInputsAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     mapping(address => int256) public balanceChanges;
     address[] changedAddresses;
 
     function triggers() public view override {
-        registerCallTrigger(this.assertionFunctionCallInputs.selector);
+        registerTxEndTrigger(this.assertionFunctionCallInputs.selector);
     }
 
-    function assertionFunctionCallInputs() public {
+    function assertionFunctionCallInputs() public view {
         Protocol protocol = Protocol(ph.getAssertionAdopter());
         PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(protocol), Protocol.transfer.selector);
 
@@ -71,16 +76,19 @@ contract FunctionCallInputsAssertion is Assertion {
         uint256 absDiff;
 
         for (uint256 i = 0; i < changedAddresses.length; i++) {
-            ph.forkPreTx();
-            preBalance = protocol.balances(changedAddresses[i]);
-            ph.forkPostTx();
+            bytes32 balanceSlot = keccak256(abi.encode(changedAddresses[i], uint256(0)));
+            PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
+            PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+
+            preBalance = uint256(ph.loadStateAt(address(protocol), balanceSlot, preTx));
+            uint256 postBalance = uint256(ph.loadStateAt(address(protocol), balanceSlot, postTx));
 
             if (balanceChanges[changedAddresses[i]] > 0) {
                 absDiff = uint256(balanceChanges[changedAddresses[i]]);
-                require(protocol.balances(changedAddresses[i]) == preBalance + absDiff, "Balance change mismatch");
+                require(postBalance == preBalance + absDiff, "Balance change mismatch");
             } else {
                 absDiff = uint256(balanceChanges[changedAddresses[i]] * -1);
-                require(protocol.balances(changedAddresses[i]) == preBalance - absDiff, "Balance change mismatch");
+                require(postBalance == preBalance - absDiff, "Balance change mismatch");
             }
         }
     }
@@ -94,7 +102,7 @@ contract FunctionCallInputsAssertion is Assertion {
     - Decode parameters using `abi.decode()` to reconstruct function arguments
 
 - **State verification:**
-    - Use `forkPreTx()` and `forkPostTx()` to compare states
+    - Use explicit `ForkId` values with `loadStateAt()` to compare states
     - Validate state changes match expected behavior based on inputs
 
 - **State tracking considerations:**

--- a/credible/use-case-mappings/read-logs.mdx
+++ b/credible/use-case-mappings/read-logs.mdx
@@ -79,8 +79,8 @@ contract ReadLogsAssertion is Assertion {
 
         for (uint256 i = 0; i < changedAddresses.length; i++) {
             bytes32 balanceSlot = keccak256(abi.encode(changedAddresses[i], uint256(0)));
-            PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
-            PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+            PhEvm.ForkId memory preTx = _preTx();
+            PhEvm.ForkId memory postTx = _postTx();
 
             preBalance = uint256(ph.loadStateAt(address(protocol), balanceSlot, preTx));
             uint256 postBalance = uint256(ph.loadStateAt(address(protocol), balanceSlot, postTx));

--- a/credible/use-case-mappings/read-logs.mdx
+++ b/credible/use-case-mappings/read-logs.mdx
@@ -20,6 +20,8 @@ description: Capture and verify logs as a signal for changes in the state of the
 Protocol:
 
 ```solidity
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
 contract Protocol {
     event Transfer(address from, address to, uint256 amount);
 
@@ -42,14 +44,18 @@ Assertion:
 
 ```solidity
 contract ReadLogsAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     mapping(address => int256) public balanceChanges;
     address[] changedAddresses;
 
     function triggers() public view override {
-        registerCallTrigger(this.assertionReadLogs.selector);
+        registerTxEndTrigger(this.assertionReadLogs.selector);
     }
 
-    function assertionReadLogs() public {
+    function assertionReadLogs() public view {
         Protocol protocol = Protocol(ph.getAssertionAdopter());
         PhEvm.Log[] memory logs = ph.getLogs();
 
@@ -72,16 +78,19 @@ contract ReadLogsAssertion is Assertion {
         uint256 absDiff;
 
         for (uint256 i = 0; i < changedAddresses.length; i++) {
-            ph.forkPreTx();
-            preBalance = protocol.balances(changedAddresses[i]);
-            ph.forkPostTx();
+            bytes32 balanceSlot = keccak256(abi.encode(changedAddresses[i], uint256(0)));
+            PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
+            PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+
+            preBalance = uint256(ph.loadStateAt(address(protocol), balanceSlot, preTx));
+            uint256 postBalance = uint256(ph.loadStateAt(address(protocol), balanceSlot, postTx));
 
             if (balanceChanges[changedAddresses[i]] > 0) {
                 absDiff = uint256(balanceChanges[changedAddresses[i]]);
-                require(protocol.balances(changedAddresses[i]) == preBalance + absDiff, "Balance change mismatch");
+                require(postBalance == preBalance + absDiff, "Balance change mismatch");
             } else {
                 absDiff = uint256(balanceChanges[changedAddresses[i]] * -1);
-                require(protocol.balances(changedAddresses[i]) == preBalance - absDiff, "Balance change mismatch");
+                require(postBalance == preBalance - absDiff, "Balance change mismatch");
             }
         }
     }
@@ -96,7 +105,7 @@ contract ReadLogsAssertion is Assertion {
     - Decode parameters using `abi.decode()` to reconstruct event arguments
 
 - **State verification:**
-    - Use `forkPreTx()` and `forkPostTx()` to compare states
+    - Use explicit `ForkId` values with `loadStateAt()` to compare states
     - Validate state changes match expected behavior based on inputs
 
 - **State tracking considerations:**

--- a/credible/use-case-mappings/state-changes.mdx
+++ b/credible/use-case-mappings/state-changes.mdx
@@ -33,9 +33,15 @@ contract MonotonicallyIncreasingValue {
 Assertion:
 
 ```solidity
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
 contract StateChangesAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     function triggers() public view override {
-        registerCallTrigger(this.assertionStateChanges.selector);
+        registerTxEndTrigger(this.assertionStateChanges.selector);
     }
 
     function assertionStateChanges() public view {

--- a/credible/use-case-mappings/storage-lookups.mdx
+++ b/credible/use-case-mappings/storage-lookups.mdx
@@ -56,7 +56,7 @@ contract StorageLookupAssertion is Assertion {
         // 1. Convert bytes32 to uint256
         // 2. Convert uint256 to uint160 (address size)
         // 3. Cast to address type
-        PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postTx = _postTx();
         address owner = address(uint160(uint256(ph.loadStateAt(address(protocol), bytes32(uint256(0)), postTx))));
 
         // Verify the owner is in the whitelist

--- a/credible/use-case-mappings/storage-lookups.mdx
+++ b/credible/use-case-mappings/storage-lookups.mdx
@@ -13,13 +13,15 @@ description: Access the value of a storage variable at a specific address. Even 
 
 ### Required Cheatcodes
 
-- `load(address target, bytes32 slot)` - Reads the raw storage value at the given slot for the specified contract address
+- `loadStateAt(address target, bytes32 slot, ForkId fork)` - Reads the raw storage value at the given slot for the specified contract address and snapshot
 
 ### Example Implementation
 
 Protocol:
 
 ```solidity
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+
 contract Protocol {
     // This variable is stored in slot 0
     address owner;
@@ -34,23 +36,28 @@ Assertion:
 
 ```solidity
 contract StorageLookupAssertion is Assertion {
-    function triggers() public view override {
-        registerCallTrigger(this.assertionStorageLookup.selector);
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
-    function assertionStorageLookup() public {
+    function triggers() public view override {
+        registerTxEndTrigger(this.assertionStorageLookup.selector);
+    }
+
+    function assertionStorageLookup() public view {
         Protocol protocol = Protocol(ph.getAssertionAdopter());
         // Define a whitelist of allowed owner addresses
         address[] memory whitelist = new address[](2);
         whitelist[0] = address(0x1);
         whitelist[1] = address(0x2);
 
-        // Read owner from storage slot 0
-        // Complex casting is needed because load() returns bytes32
+        // Read owner from storage slot 0 at the post-transaction snapshot.
+        // Complex casting is needed because loadStateAt() returns bytes32.
         // 1. Convert bytes32 to uint256
         // 2. Convert uint256 to uint160 (address size)
         // 3. Cast to address type
-        address owner = address(uint160(uint256(ph.load(address(protocol), bytes32(uint256(0))))));
+        PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        address owner = address(uint160(uint256(ph.loadStateAt(address(protocol), bytes32(uint256(0)), postTx))));
 
         // Verify the owner is in the whitelist
         for (uint256 i = 0; i < whitelist.length; i++) {

--- a/credible/write-first-assertion.mdx
+++ b/credible/write-first-assertion.mdx
@@ -100,8 +100,8 @@ contract OwnableAssertion is Assertion {
     function assertionOwnershipChange() external view {
         Ownable ownable = Ownable(ph.getAssertionAdopter());
 
-        PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory preTx = _preTx();
+        PhEvm.ForkId memory postTx = _postTx();
 
         address preOwner = address(uint160(uint256(ph.loadStateAt(address(ownable), bytes32(uint256(0)), preTx))));
         address postOwner = address(uint160(uint256(ph.loadStateAt(address(ownable), bytes32(uint256(0)), postTx))));
@@ -157,8 +157,8 @@ See [Triggers](./triggers) for more trigger types and optimization.
 function assertionOwnershipChange() external view {
     Ownable ownable = Ownable(ph.getAssertionAdopter());
 
-    PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
-    PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
+    PhEvm.ForkId memory preTx = _preTx();
+    PhEvm.ForkId memory postTx = _postTx();
 
     address preOwner = address(uint160(uint256(ph.loadStateAt(address(ownable), bytes32(uint256(0)), preTx))));
     address postOwner = address(uint160(uint256(ph.loadStateAt(address(ownable), bytes32(uint256(0)), postTx))));

--- a/credible/write-first-assertion.mdx
+++ b/credible/write-first-assertion.mdx
@@ -84,21 +84,27 @@ Create `assertions/src/OwnableAssertion.a.sol`:
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+import {PhEvm} from "credible-std/PhEvm.sol";
 import {Ownable} from "../../src/Ownable.sol";
 
 contract OwnableAssertion is Assertion {
-    function triggers() external view override {
-        registerCallTrigger(this.assertionOwnershipChange.selector, Ownable.transferOwnership.selector);
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
-    function assertionOwnershipChange() external {
+    function triggers() external view override {
+        registerFnCallTrigger(this.assertionOwnershipChange.selector, Ownable.transferOwnership.selector);
+    }
+
+    function assertionOwnershipChange() external view {
         Ownable ownable = Ownable(ph.getAssertionAdopter());
 
-        ph.forkPreTx();
-        address preOwner = ownable.owner();
+        PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
+        PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
-        ph.forkPostTx();
-        address postOwner = ownable.owner();
+        address preOwner = address(uint160(uint256(ph.loadStateAt(address(ownable), bytes32(uint256(0)), preTx))));
+        address postOwner = address(uint160(uint256(ph.loadStateAt(address(ownable), bytes32(uint256(0)), postTx))));
 
         require(postOwner == preOwner, "Ownership has changed");
     }
@@ -117,7 +123,12 @@ In general: **if an assertion reverts, the transaction is blocked.** This preven
 
 ```solidity
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 contract OwnableAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
 ```
 
 The `Assertion` base class provides [cheatcodes](./glossary#cheatcodes) via the `ph` namespace.
@@ -126,7 +137,7 @@ The `Assertion` base class provides [cheatcodes](./glossary#cheatcodes) via the 
 
 ```solidity
 function triggers() external view override {
-    registerCallTrigger(this.assertionOwnershipChange.selector, Ownable.transferOwnership.selector);
+    registerFnCallTrigger(this.assertionOwnershipChange.selector, Ownable.transferOwnership.selector);
 }
 ```
 
@@ -143,22 +154,22 @@ See [Triggers](./triggers) for more trigger types and optimization.
 **Assertion logic:**
 
 ```solidity
-function assertionOwnershipChange() external {
+function assertionOwnershipChange() external view {
     Ownable ownable = Ownable(ph.getAssertionAdopter());
 
-    ph.forkPreTx();
-    address preOwner = ownable.owner();
+    PhEvm.ForkId memory preTx = PhEvm.ForkId({forkType: 0, callIndex: 0});
+    PhEvm.ForkId memory postTx = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
-    ph.forkPostTx();
-    address postOwner = ownable.owner();
+    address preOwner = address(uint160(uint256(ph.loadStateAt(address(ownable), bytes32(uint256(0)), preTx))));
+    address postOwner = address(uint160(uint256(ph.loadStateAt(address(ownable), bytes32(uint256(0)), postTx))));
 
     require(postOwner == preOwner, "Ownership has changed");
 }
 ```
 
 - `ph.getAssertionAdopter()`: Returns the protected contract's address
-- `ph.forkPreTx()`: Switches to state before the transaction
-- `ph.forkPostTx()`: Switches to state after the transaction
+- `PhEvm.ForkId`: Identifies the pre-transaction and post-transaction snapshots
+- `ph.loadStateAt()`: Reads the protected contract's owner slot at the requested snapshot
 - The `require` blocks the transaction if ownership changed
 
 ### Best Practices
@@ -166,7 +177,7 @@ function assertionOwnershipChange() external {
 1. **Single responsibility**: Each assertion should verify one property
 2. **Use triggers efficiently**: Only run assertions when relevant functions are called
 3. **Return early**: Check simple conditions before complex logic
-4. **Use `forkPreCall`/`forkPostCall`**: For checking state around specific nested calls within a transaction, not just the overall transaction
+4. **Use explicit `ForkId`s**: For checks around a matched call, use `ph.context()` and construct `PhEvm.ForkId({forkType: 2, callIndex: ctx.callStart})` or `PhEvm.ForkId({forkType: 3, callIndex: ctx.callEnd})`.
 
 ## Step 3: Test the Assertion
 

--- a/docs.json
+++ b/docs.json
@@ -243,11 +243,23 @@
                 ]
               },
               {
+                "group": "Oracle Security",
+                "pages": [
+                  "assertions-book/assertions/ass10-oracle-validation",
+                  "assertions-book/assertions/ass11-twap-deviation",
+                  "assertions-book/assertions/ass28-intra-tx-oracle-deviation"
+                ]
+              },
+              {
                 "group": "Circuit Breakers",
                 "pages": [
                   "assertions-book/assertions/ass20-erc20-drain",
                   "assertions-book/assertions/ass22-erc20-inflow-breaker"
                 ]
+              },
+              {
+                "group": "Native Asset Protection",
+                "pages": ["assertions-book/assertions/ass21-ether-drain"]
               },
               {
                 "group": "Vault and ERC4626 Security",

--- a/docs.json
+++ b/docs.json
@@ -243,11 +243,10 @@
                 ]
               },
               {
-                "group": "Oracle Security",
+                "group": "Circuit Breakers",
                 "pages": [
-                  "assertions-book/assertions/ass10-oracle-validation",
-                  "assertions-book/assertions/ass11-twap-deviation",
-                  "assertions-book/assertions/ass28-intra-tx-oracle-deviation"
+                  "assertions-book/assertions/ass20-erc20-drain",
+                  "assertions-book/assertions/ass22-erc20-inflow-breaker"
                 ]
               },
               {
@@ -261,13 +260,6 @@
               {
                 "group": "Emergency and Special Mode Protection",
                 "pages": ["assertions-book/assertions/ass17-panic-state-validation"]
-              },
-              {
-                "group": "Fund Protection",
-                "pages": [
-                  "assertions-book/assertions/ass20-erc20-drain",
-                  "assertions-book/assertions/ass21-ether-drain"
-                ]
               }
             ]
           }

--- a/scripts/run-mint.sh
+++ b/scripts/run-mint.sh
@@ -28,8 +28,9 @@ if [[ -s "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]]; then
   unset npm_config_prefix
   # shellcheck source=/dev/null
   . "${NVM_DIR:-$HOME/.nvm}/nvm.sh"
-  nvm use "$required_node" >/dev/null
-  run_mint "$@"
+  if nvm use "$required_node" >/dev/null 2>&1; then
+    run_mint "$@"
+  fi
 fi
 
 cat <<EOF >&2
@@ -39,10 +40,12 @@ Current Node: $(node -v 2>/dev/null || echo "not found")
 
 If you use nvm:
   source "\$HOME/.nvm/nvm.sh"
+  nvm install $required_node
   nvm use $required_node
+  corepack enable
   pnpm dev
 
-Supported shortcuts after this change:
+Supported shortcuts:
   pnpm dev
   npm run dev
   npm start

--- a/scripts/run-mint.sh
+++ b/scripts/run-mint.sh
@@ -33,6 +33,15 @@ if [[ -s "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]]; then
   fi
 fi
 
+homebrew_node="/opt/homebrew/opt/node@$required_node/bin/node"
+if [[ -x "$homebrew_node" ]]; then
+  homebrew_major="$("$homebrew_node" -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo "")"
+  if [[ "$homebrew_major" == "$required_node" ]]; then
+    export PATH="/opt/homebrew/opt/node@$required_node/bin:$PATH"
+    run_mint "$@"
+  fi
+fi
+
 cat <<EOF >&2
 This repo requires Node $required_node.x to run Mintlify commands.
 
@@ -42,6 +51,12 @@ If you use nvm:
   source "\$HOME/.nvm/nvm.sh"
   nvm install $required_node
   nvm use $required_node
+  corepack enable
+  pnpm dev
+
+If you use Homebrew:
+  brew install node@$required_node
+  export PATH="/opt/homebrew/opt/node@$required_node/bin:\$PATH"
   corepack enable
   pnpm dev
 

--- a/snippets/ass1-implementation-change.a.mdx
+++ b/snippets/ass1-implementation-change.a.mdx
@@ -3,13 +3,18 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract ImplementationChangeAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     function triggers() external view override {
         // Register trigger for changes to the implementation address storage slot
         // The implementation address is typically stored in the first storage slot (slot 0)
-        registerStorageChangeTrigger(this.implementationChange.selector, bytes32(uint256(0)));
+        registerTxEndTrigger(this.implementationChange.selector);
     }
 
     // Assert that the implementation contract address doesn't change
@@ -19,11 +24,11 @@ contract ImplementationChangeAssertion is Assertion {
         IImplementation adopter = IImplementation(ph.getAssertionAdopter());
 
         // Get pre-state implementation
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         address preImpl = adopter.implementation();
 
         // Get post-state implementation
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         address postImpl = adopter.implementation();
 
         // Get all state changes for the implementation slot

--- a/snippets/ass1-implementation-change.a.mdx
+++ b/snippets/ass1-implementation-change.a.mdx
@@ -7,47 +7,30 @@ import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract ImplementationChangeAssertion is Assertion {
+    bytes32 internal constant IMPLEMENTATION_SLOT = bytes32(uint256(0));
+
     constructor() {
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
     function triggers() external view override {
-        // Register trigger for changes to the implementation address storage slot
-        // The implementation address is typically stored in the first storage slot (slot 0)
         registerTxEndTrigger(this.implementationChange.selector);
     }
 
-    // Assert that the implementation contract address doesn't change
-    // during the state transition
-    function implementationChange() external {
-        // Get the assertion adopter address
-        IImplementation adopter = IImplementation(ph.getAssertionAdopter());
-
-        // Get pre-state implementation
+    /// @notice Checks that the implementation slot is unchanged across the transaction.
+    function implementationChange() external view {
+        address adopter = ph.getAssertionAdopter();
         PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        address preImpl = adopter.implementation();
-
-        // Get post-state implementation
         PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-        address postImpl = adopter.implementation();
 
-        // Get all state changes for the implementation slot
-        address[] memory changes = getStateChangesAddress(
-            address(adopter),
-            bytes32(uint256(0)) // First storage slot for implementation address
-        );
+        address preImpl = _loadAddressAt(adopter, IMPLEMENTATION_SLOT, preFork);
+        address postImpl = _loadAddressAt(adopter, IMPLEMENTATION_SLOT, postFork);
 
-        // Verify implementation hasn't changed
         require(preImpl == postImpl, "Implementation changed");
-
-        // Additional check: verify no unauthorized changes to implementation slot
-        for (uint256 i = 0; i < changes.length; i++) {
-            require(changes[i] == preImpl, "Unauthorized implementation change detected");
-        }
     }
-}
 
-interface IImplementation {
-    function implementation() external view returns (address);
+    function _loadAddressAt(address target, bytes32 slot, PhEvm.ForkId memory fork) internal view returns (address) {
+        return address(uint160(uint256(ph.loadStateAt(target, slot, fork))));
+    }
 }
 ```

--- a/snippets/ass1-implementation-change.a.mdx
+++ b/snippets/ass1-implementation-change.a.mdx
@@ -20,8 +20,8 @@ contract ImplementationChangeAssertion is Assertion {
     /// @notice Checks that the implementation slot is unchanged across the transaction.
     function implementationChange() external view {
         address adopter = ph.getAssertionAdopter();
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
+        PhEvm.ForkId memory postFork = _postTx();
 
         address preImpl = _loadAddressAt(adopter, IMPLEMENTATION_SLOT, preFork);
         address postImpl = _loadAddressAt(adopter, IMPLEMENTATION_SLOT, postFork);

--- a/snippets/ass10-oracle-liveness.a.mdx
+++ b/snippets/ass10-oracle-liveness.a.mdx
@@ -3,16 +3,21 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract OracleLivenessAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     // Maximum time window (in seconds) that oracle data can be considered fresh
     // This is a constant that should be adjusted based on the protocol's requirements
     uint256 public constant MAX_UPDATE_WINDOW = 10 minutes;
 
     function triggers() external view override {
         // Register trigger for the swap function which relies on oracle data
-        registerCallTrigger(this.assertionOracleLiveness.selector, IDex.swap.selector);
+        registerFnCallTrigger(this.assertionOracleLiveness.selector, IDex.swap.selector);
     }
 
     // Assert that the oracle has been updated within the specified time window
@@ -21,7 +26,7 @@ contract OracleLivenessAssertion is Assertion {
         IDex adopter = IDex(ph.getAssertionAdopter());
 
         // Get the current state to check the oracle's last update time
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
         // Check if the oracle has been updated within the maximum allowed window
         uint256 lastUpdateTime = IOracle(adopter.oracle()).lastUpdated();

--- a/snippets/ass10-oracle-liveness.a.mdx
+++ b/snippets/ass10-oracle-liveness.a.mdx
@@ -26,7 +26,7 @@ contract OracleLivenessAssertion is Assertion {
         IDex adopter = IDex(ph.getAssertionAdopter());
 
         // Get the current state to check the oracle's last update time
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
 
         // Check if the oracle has been updated within the maximum allowed window
         uint256 lastUpdateTime = IOracle(adopter.oracle()).lastUpdated();

--- a/snippets/ass11-twap-deviation.a.mdx
+++ b/snippets/ass11-twap-deviation.a.mdx
@@ -3,13 +3,18 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract TwapDeviationAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     function triggers() external view override {
         // Register trigger for changes to the current price
         // We assume that the price is stored in storage slot 0
-        registerStorageChangeTrigger(this.assertionTwapDeviation.selector, bytes32(uint256(0)));
+        registerTxEndTrigger(this.assertionTwapDeviation.selector);
     }
 
     // Assert that the current price doesn't deviate more than 5% from the TWAP price
@@ -18,11 +23,11 @@ contract TwapDeviationAssertion is Assertion {
         IPool adopter = IPool(ph.getAssertionAdopter());
 
         // Get TWAP price before the transaction (our reference point)
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 preTwapPrice = adopter.twap();
 
         // Get price after the transaction
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 postPrice = adopter.price();
 
         uint256 maxDeviation = 5;

--- a/snippets/ass11-twap-deviation.a.mdx
+++ b/snippets/ass11-twap-deviation.a.mdx
@@ -23,11 +23,11 @@ contract TwapDeviationAssertion is Assertion {
         IPool adopter = IPool(ph.getAssertionAdopter());
 
         // Get TWAP price before the transaction (our reference point)
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
         uint256 preTwapPrice = adopter.twap();
 
         // Get price after the transaction
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
         uint256 postPrice = adopter.price();
 
         uint256 maxDeviation = 5;

--- a/snippets/ass12-erc4626-assets-shares.a.mdx
+++ b/snippets/ass12-erc4626-assets-shares.a.mdx
@@ -7,6 +7,9 @@ import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract ERC4626AssetsSharesAssertion is Assertion {
+    bytes32 internal constant TOTAL_ASSETS_SLOT = bytes32(uint256(0));
+    bytes32 internal constant TOTAL_SUPPLY_SLOT = bytes32(uint256(1));
+
     constructor() {
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
@@ -15,26 +18,15 @@ contract ERC4626AssetsSharesAssertion is Assertion {
         registerTxEndTrigger(this.assertionAssetsShares.selector);
     }
 
-    // Assert that the total assets are sufficient to back all shares
+    /// @notice Checks that stored total assets are sufficient to back stored total shares.
     function assertionAssetsShares() external view {
-        // Get the assertion adopter address
-        IERC4626 adopter = IERC4626(ph.getAssertionAdopter());
+        address vault = ph.getAssertionAdopter();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
-        uint256 totalAssets = adopter.totalAssets();
-        uint256 totalSupply = adopter.totalSupply();
+        uint256 totalAssets = uint256(ph.loadStateAt(vault, TOTAL_ASSETS_SLOT, postFork));
+        uint256 totalSupply = uint256(ph.loadStateAt(vault, TOTAL_SUPPLY_SLOT, postFork));
 
-        // Calculate how many assets are needed to back all shares
-        uint256 requiredAssets = adopter.convertToAssets(totalSupply);
-
-        // The total assets should be at least what's needed to back all shares
-        require(totalAssets >= requiredAssets, "Not enough assets to back all shares");
+        require(totalAssets >= totalSupply, "Not enough assets to back all shares");
     }
-}
-
-interface IERC4626 {
-    function totalAssets() external view returns (uint256);
-    function totalSupply() external view returns (uint256);
-    function convertToShares(uint256 assets) external view returns (uint256);
-    function convertToAssets(uint256 shares) external view returns (uint256);
 }
 ```

--- a/snippets/ass12-erc4626-assets-shares.a.mdx
+++ b/snippets/ass12-erc4626-assets-shares.a.mdx
@@ -21,7 +21,7 @@ contract ERC4626AssetsSharesAssertion is Assertion {
     /// @notice Checks that stored total assets are sufficient to back stored total shares.
     function assertionAssetsShares() external view {
         address vault = ph.getAssertionAdopter();
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
 
         uint256 totalAssets = uint256(ph.loadStateAt(vault, TOTAL_ASSETS_SLOT, postFork));
         uint256 totalSupply = uint256(ph.loadStateAt(vault, TOTAL_SUPPLY_SLOT, postFork));

--- a/snippets/ass12-erc4626-assets-shares.a.mdx
+++ b/snippets/ass12-erc4626-assets-shares.a.mdx
@@ -3,15 +3,16 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract ERC4626AssetsSharesAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     function triggers() external view override {
-        // Register trigger specifically for changes to the total supply storage slot
-        registerStorageChangeTrigger(
-            this.assertionAssetsShares.selector,
-            bytes32(uint256(1)) // Total supply storage slot
-        );
+        registerTxEndTrigger(this.assertionAssetsShares.selector);
     }
 
     // Assert that the total assets are sufficient to back all shares

--- a/snippets/ass13-erc4626-deposit-withdraw.a.mdx
+++ b/snippets/ass13-erc4626-deposit-withdraw.a.mdx
@@ -3,9 +3,14 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract ERC4626DepositWithdrawAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     // Used to store the last known good share value
     uint256 private lastKnownShareValue;
 
@@ -14,17 +19,17 @@ contract ERC4626DepositWithdrawAssertion is Assertion {
 
     function triggers() external view override {
         // Register triggers for deposit operations
-        registerCallTrigger(this.assertionDepositAssets.selector, IERC4626.deposit.selector);
-        registerCallTrigger(this.assertionDepositShares.selector, IERC4626.deposit.selector);
+        registerFnCallTrigger(this.assertionDepositAssets.selector, IERC4626.deposit.selector);
+        registerFnCallTrigger(this.assertionDepositShares.selector, IERC4626.deposit.selector);
 
         // Register triggers for withdraw operations
-        registerCallTrigger(this.assertionWithdrawAssets.selector, IERC4626.withdraw.selector);
-        registerCallTrigger(this.assertionWithdrawShares.selector, IERC4626.withdraw.selector);
+        registerFnCallTrigger(this.assertionWithdrawAssets.selector, IERC4626.withdraw.selector);
+        registerFnCallTrigger(this.assertionWithdrawShares.selector, IERC4626.withdraw.selector);
 
         // Register trigger for share value monotonicity
         // This can be triggered by various operations
-        registerCallTrigger(this.assertionShareValueMonotonicity.selector, IERC4626.deposit.selector);
-        registerCallTrigger(this.assertionShareValueMonotonicity.selector, IERC4626.withdraw.selector);
+        registerFnCallTrigger(this.assertionShareValueMonotonicity.selector, IERC4626.deposit.selector);
+        registerFnCallTrigger(this.assertionShareValueMonotonicity.selector, IERC4626.withdraw.selector);
     }
 
     // Assert that deposits correctly update total assets
@@ -36,11 +41,11 @@ contract ERC4626DepositWithdrawAssertion is Assertion {
         PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(adopter), adopter.deposit.selector);
 
         // First, do a simple pre/post state check for the overall transaction
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 preTotalAssets = adopter.totalAssets();
 
         // Get post-state values
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 postTotalAssets = adopter.totalAssets();
 
         // Calculate total assets deposited across all calls
@@ -66,12 +71,12 @@ contract ERC4626DepositWithdrawAssertion is Assertion {
         PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(adopter), adopter.deposit.selector);
 
         // Get pre-state values for total assets and total supply
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 preTotalAssets = adopter.totalAssets();
         uint256 preTotalSupply = adopter.totalSupply();
 
         // Get post-state values for total assets and total supply
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 postTotalAssets = adopter.totalAssets();
         uint256 postTotalSupply = adopter.totalSupply();
 
@@ -84,9 +89,9 @@ contract ERC4626DepositWithdrawAssertion is Assertion {
             totalAssetsDeposited += assets;
 
             // Get pre and post share balances for this receiver
-            ph.forkPreTx();
+            PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
             uint256 preShareBalance = adopter.balanceOf(receiver);
-            ph.forkPostTx();
+            PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
             uint256 postShareBalance = adopter.balanceOf(receiver);
 
             totalSharesMinted += (postShareBalance - preShareBalance);
@@ -125,11 +130,11 @@ contract ERC4626DepositWithdrawAssertion is Assertion {
         PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(adopter), adopter.withdraw.selector);
 
         // First, do a simple pre/post state check for the overall transaction
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 preTotalAssets = adopter.totalAssets();
 
         // Get post-state values
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 postTotalAssets = adopter.totalAssets();
 
         // Calculate total assets withdrawn across all calls
@@ -155,12 +160,12 @@ contract ERC4626DepositWithdrawAssertion is Assertion {
         PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(adopter), adopter.withdraw.selector);
 
         // Get pre-state values for total assets and total supply
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 preTotalAssets = adopter.totalAssets();
         uint256 preTotalSupply = adopter.totalSupply();
 
         // Get post-state values for total assets and total supply
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 postTotalAssets = adopter.totalAssets();
         uint256 postTotalSupply = adopter.totalSupply();
 
@@ -173,9 +178,9 @@ contract ERC4626DepositWithdrawAssertion is Assertion {
             totalAssetsWithdrawn += assets;
 
             // Get pre and post share balances for this owner
-            ph.forkPreTx();
+            PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
             uint256 preShareBalance = adopter.balanceOf(owner);
-            ph.forkPostTx();
+            PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
             uint256 postShareBalance = adopter.balanceOf(owner);
 
             totalSharesBurned += (preShareBalance - postShareBalance);
@@ -211,11 +216,11 @@ contract ERC4626DepositWithdrawAssertion is Assertion {
         IERC4626 adopter = IERC4626(ph.getAssertionAdopter());
 
         // Create a snapshot of the state before any transactions
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 assetsPerSharePre = _calculateAssetsPerShare(adopter);
 
         // Get state after transaction
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 assetsPerSharePost = _calculateAssetsPerShare(adopter);
 
         // Allow for minimal precision/rounding errors with a small tolerance

--- a/snippets/ass13-erc4626-deposit-withdraw.a.mdx
+++ b/snippets/ass13-erc4626-deposit-withdraw.a.mdx
@@ -31,7 +31,7 @@ contract ERC4626DepositWithdrawAssertion is Assertion {
         _assertSharePriceNotReduced(ctx.callStart, ctx.callEnd, "ERC4626: withdrawal diluted shares");
     }
 
-    function _assertSharePriceNotReduced(uint64 callStart, uint64 callEnd, string memory reason) internal view {
+    function _assertSharePriceNotReduced(uint256 callStart, uint256 callEnd, string memory reason) internal view {
         address vault = ph.getAssertionAdopter();
         PhEvm.ForkId memory preCall = PhEvm.ForkId({forkType: 2, callIndex: callStart});
         PhEvm.ForkId memory postCall = PhEvm.ForkId({forkType: 3, callIndex: callEnd});

--- a/snippets/ass13-erc4626-deposit-withdraw.a.mdx
+++ b/snippets/ass13-erc4626-deposit-withdraw.a.mdx
@@ -7,283 +7,50 @@ import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract ERC4626DepositWithdrawAssertion is Assertion {
+    bytes32 internal constant TOTAL_ASSETS_SLOT = bytes32(uint256(0));
+    bytes32 internal constant TOTAL_SUPPLY_SLOT = bytes32(uint256(1));
+
     constructor() {
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
-    // Used to store the last known good share value
-    uint256 private lastKnownShareValue;
-
-    // Tolerance for precision/rounding errors (0.01%)
-    uint256 private constant PRECISION_TOLERANCE = 1e14; // 0.01% of 1e18
-
     function triggers() external view override {
-        // Register triggers for deposit operations
-        registerFnCallTrigger(this.assertionDepositAssets.selector, IERC4626.deposit.selector);
-        registerFnCallTrigger(this.assertionDepositShares.selector, IERC4626.deposit.selector);
-
-        // Register triggers for withdraw operations
-        registerFnCallTrigger(this.assertionWithdrawAssets.selector, IERC4626.withdraw.selector);
-        registerFnCallTrigger(this.assertionWithdrawShares.selector, IERC4626.withdraw.selector);
-
-        // Register trigger for share value monotonicity
-        // This can be triggered by various operations
-        registerFnCallTrigger(this.assertionShareValueMonotonicity.selector, IERC4626.deposit.selector);
-        registerFnCallTrigger(this.assertionShareValueMonotonicity.selector, IERC4626.withdraw.selector);
+        registerFnCallTrigger(this.assertDepositPreservesSharePrice.selector, IERC4626.deposit.selector);
+        registerFnCallTrigger(this.assertWithdrawPreservesSharePrice.selector, IERC4626.withdraw.selector);
     }
 
-    // Assert that deposits correctly update total assets
-    function assertionDepositAssets() external {
-        // Get the assertion adopter address
-        IERC4626 adopter = IERC4626(ph.getAssertionAdopter());
-
-        // Get all deposit calls to the ERC4626 vault
-        PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(adopter), adopter.deposit.selector);
-
-        // First, do a simple pre/post state check for the overall transaction
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        uint256 preTotalAssets = adopter.totalAssets();
-
-        // Get post-state values
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-        uint256 postTotalAssets = adopter.totalAssets();
-
-        // Calculate total assets deposited across all calls
-        uint256 totalAssetsDeposited = 0;
-        for (uint256 i = 0; i < callInputs.length; i++) {
-            (uint256 assets,) = abi.decode(callInputs[i].input, (uint256, address));
-            totalAssetsDeposited += assets;
-        }
-
-        // Verify total assets increased by exactly the deposited amount
-        require(
-            postTotalAssets == preTotalAssets + totalAssetsDeposited,
-            "Deposit assets assertion failed: incorrect total assets"
-        );
+    /// @notice Checks that a deposit does not dilute existing shares.
+    function assertDepositPreservesSharePrice() external view {
+        PhEvm.TriggerContext memory ctx = ph.context();
+        _assertSharePriceNotReduced(ctx.callStart, ctx.callEnd, "ERC4626: deposit diluted shares");
     }
 
-    // Assert that deposits maintain correct share accounting
-    function assertionDepositShares() external {
-        // Get the assertion adopter address
-        IERC4626 adopter = IERC4626(ph.getAssertionAdopter());
-
-        // Get all deposit calls to the ERC4626 vault
-        PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(adopter), adopter.deposit.selector);
-
-        // Get pre-state values for total assets and total supply
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        uint256 preTotalAssets = adopter.totalAssets();
-        uint256 preTotalSupply = adopter.totalSupply();
-
-        // Get post-state values for total assets and total supply
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-        uint256 postTotalAssets = adopter.totalAssets();
-        uint256 postTotalSupply = adopter.totalSupply();
-
-        // Calculate total assets deposited and total shares minted across all calls
-        uint256 totalAssetsDeposited = 0;
-        uint256 totalSharesMinted = 0;
-
-        for (uint256 i = 0; i < callInputs.length; i++) {
-            (uint256 assets, address receiver) = abi.decode(callInputs[i].input, (uint256, address));
-            totalAssetsDeposited += assets;
-
-            // Get pre and post share balances for this receiver
-            PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-            uint256 preShareBalance = adopter.balanceOf(receiver);
-            PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-            uint256 postShareBalance = adopter.balanceOf(receiver);
-
-            totalSharesMinted += (postShareBalance - preShareBalance);
-        }
-
-        // Verify that total assets increased by exactly the deposited amount
-        require(
-            postTotalAssets == preTotalAssets + totalAssetsDeposited,
-            "Deposit shares assertion failed: total assets not updated correctly"
-        );
-
-        // Verify that total supply increased by exactly the minted shares
-        require(
-            postTotalSupply == preTotalSupply + totalSharesMinted,
-            "Deposit shares assertion failed: total supply not updated correctly"
-        );
-
-        // Verify that the share-to-asset ratio remains consistent
-        // This is the key check that will catch the vulnerability
-        uint256 preAssetsPerShare = preTotalSupply > 0 ? (preTotalAssets * 1e18) / preTotalSupply : 0;
-        uint256 postAssetsPerShare = postTotalSupply > 0 ? (postTotalAssets * 1e18) / postTotalSupply : 0;
-
-        // Allow for minimal precision/rounding errors
-        require(
-            postAssetsPerShare >= preAssetsPerShare || preAssetsPerShare - postAssetsPerShare <= PRECISION_TOLERANCE,
-            "Deposit shares assertion failed: share-to-asset ratio decreased unexpectedly"
-        );
+    /// @notice Checks that a withdrawal does not dilute remaining shares.
+    function assertWithdrawPreservesSharePrice() external view {
+        PhEvm.TriggerContext memory ctx = ph.context();
+        _assertSharePriceNotReduced(ctx.callStart, ctx.callEnd, "ERC4626: withdrawal diluted shares");
     }
 
-    // Assert that withdrawals correctly update total assets
-    function assertionWithdrawAssets() external {
-        // Get the assertion adopter address
-        IERC4626 adopter = IERC4626(ph.getAssertionAdopter());
+    function _assertSharePriceNotReduced(uint64 callStart, uint64 callEnd, string memory reason) internal view {
+        address vault = ph.getAssertionAdopter();
+        PhEvm.ForkId memory preCall = PhEvm.ForkId({forkType: 2, callIndex: callStart});
+        PhEvm.ForkId memory postCall = PhEvm.ForkId({forkType: 3, callIndex: callEnd});
 
-        // Get all withdraw calls to the ERC4626 vault
-        PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(adopter), adopter.withdraw.selector);
+        uint256 preAssets = uint256(ph.loadStateAt(vault, TOTAL_ASSETS_SLOT, preCall));
+        uint256 preSupply = uint256(ph.loadStateAt(vault, TOTAL_SUPPLY_SLOT, preCall));
+        uint256 postAssets = uint256(ph.loadStateAt(vault, TOTAL_ASSETS_SLOT, postCall));
+        uint256 postSupply = uint256(ph.loadStateAt(vault, TOTAL_SUPPLY_SLOT, postCall));
 
-        // First, do a simple pre/post state check for the overall transaction
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        uint256 preTotalAssets = adopter.totalAssets();
-
-        // Get post-state values
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-        uint256 postTotalAssets = adopter.totalAssets();
-
-        // Calculate total assets withdrawn across all calls
-        uint256 totalAssetsWithdrawn = 0;
-        for (uint256 i = 0; i < callInputs.length; i++) {
-            (uint256 assets,,) = abi.decode(callInputs[i].input, (uint256, address, address));
-            totalAssetsWithdrawn += assets;
+        if (preSupply == 0 || postSupply == 0) {
+            return;
         }
 
-        // Verify total assets decreased by exactly the withdrawn amount
-        require(
-            postTotalAssets == preTotalAssets - totalAssetsWithdrawn,
-            "Withdraw assets assertion failed: incorrect total assets"
-        );
-    }
-
-    // Assert that withdrawals maintain correct share accounting
-    function assertionWithdrawShares() external {
-        // Get the assertion adopter address
-        IERC4626 adopter = IERC4626(ph.getAssertionAdopter());
-
-        // Get all withdraw calls to the ERC4626 vault
-        PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(adopter), adopter.withdraw.selector);
-
-        // Get pre-state values for total assets and total supply
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        uint256 preTotalAssets = adopter.totalAssets();
-        uint256 preTotalSupply = adopter.totalSupply();
-
-        // Get post-state values for total assets and total supply
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-        uint256 postTotalAssets = adopter.totalAssets();
-        uint256 postTotalSupply = adopter.totalSupply();
-
-        // Calculate total assets withdrawn and total shares burned across all calls
-        uint256 totalAssetsWithdrawn = 0;
-        uint256 totalSharesBurned = 0;
-
-        for (uint256 i = 0; i < callInputs.length; i++) {
-            (uint256 assets,, address owner) = abi.decode(callInputs[i].input, (uint256, address, address));
-            totalAssetsWithdrawn += assets;
-
-            // Get pre and post share balances for this owner
-            PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-            uint256 preShareBalance = adopter.balanceOf(owner);
-            PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-            uint256 postShareBalance = adopter.balanceOf(owner);
-
-            totalSharesBurned += (preShareBalance - postShareBalance);
-        }
-
-        // Verify that total assets decreased by exactly the withdrawn amount
-        require(
-            postTotalAssets == preTotalAssets - totalAssetsWithdrawn,
-            "Withdraw shares assertion failed: total assets not updated correctly"
-        );
-
-        // Verify that total supply decreased by exactly the burned shares
-        require(
-            postTotalSupply == preTotalSupply - totalSharesBurned,
-            "Withdraw shares assertion failed: total supply not updated correctly"
-        );
-
-        // Verify that the share-to-asset ratio remains consistent
-        // This is the key check that will catch the vulnerability
-        uint256 preAssetsPerShare = preTotalSupply > 0 ? (preTotalAssets * 1e18) / preTotalSupply : 0;
-        uint256 postAssetsPerShare = postTotalSupply > 0 ? (postTotalAssets * 1e18) / postTotalSupply : 0;
-
-        // Allow for minimal precision/rounding errors
-        require(
-            postAssetsPerShare >= preAssetsPerShare || preAssetsPerShare - postAssetsPerShare <= PRECISION_TOLERANCE,
-            "Withdraw shares assertion failed: share-to-asset ratio decreased unexpectedly"
-        );
-    }
-
-    // Assert that share value never decreases unexpectedly
-    function assertionShareValueMonotonicity() external {
-        // Get the assertion adopter address
-        IERC4626 adopter = IERC4626(ph.getAssertionAdopter());
-
-        // Create a snapshot of the state before any transactions
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        uint256 assetsPerSharePre = _calculateAssetsPerShare(adopter);
-
-        // Get state after transaction
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-        uint256 assetsPerSharePost = _calculateAssetsPerShare(adopter);
-
-        // Allow for minimal precision/rounding errors with a small tolerance
-        require(
-            assetsPerSharePost >= assetsPerSharePre || assetsPerSharePre - assetsPerSharePost <= PRECISION_TOLERANCE,
-            "Share value decreased unexpectedly"
-        );
-
-        // If share value increased, update the last known good value
-        if (assetsPerSharePost > assetsPerSharePre) {
-            lastKnownShareValue = assetsPerSharePost;
-        }
-
-        // Note: In practice, you would want to add detection for legitimate cases where
-        // share value might decrease, such as:
-        //
-        // 1. Fee collection events - Some vaults charge periodic fees by reducing share value
-        //    This could be detected by:
-        //    - Checking specific fee collection function calls
-        //    - Looking for fee events emitted by the vault
-        //    - Using a timestamp-based approach to see if a fee collection period has occurred
-        //    - Adding a fee collection flag or method to the vault interface
-        //
-        // 2. Investment loss events - When underlying investments lose value
-        //    This could be detected by:
-        //    - Monitoring for loss events emitted by the vault
-        //    - Tracking investment strategy function calls that might result in losses
-        //    - Detecting significant changes in underlying asset values
-        //    - Adding a loss event flag or method to the vault interface
-        //
-        // These detection mechanisms should be customized based on the specific
-        // implementation of the vault you're working with.
-    }
-
-    // Helper function to calculate assets per share with 1e18 precision
-    function _calculateAssetsPerShare(IERC4626 vault) internal view returns (uint256) {
-        uint256 totalSupply = vault.totalSupply();
-        if (totalSupply == 0) {
-            return lastKnownShareValue; // Return last known value if supply is zero
-        }
-
-        uint256 totalAssets = vault.totalAssets();
-        return (totalAssets * 1e18) / totalSupply;
+        require(postAssets * preSupply >= preAssets * postSupply, reason);
     }
 }
 
 interface IERC4626 {
-    // Deposit/mint
-    function deposit(uint256 assets, address receiver) external returns (uint256);
-    function previewDeposit(uint256 assets) external view returns (uint256);
-
-    // Withdraw/redeem
-    function withdraw(uint256 assets, address receiver, address owner) external returns (uint256);
-    function previewWithdraw(uint256 assets) external view returns (uint256);
-
-    // View functions
-    function totalAssets() external view returns (uint256);
-    function totalSupply() external view returns (uint256);
-    function balanceOf(address account) external view returns (uint256);
-    function asset() external view returns (address);
-}
-
-interface IERC20 {
-    function balanceOf(address account) external view returns (uint256);
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+    function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares);
 }
 ```

--- a/snippets/ass14-fee-verification.a.mdx
+++ b/snippets/ass14-fee-verification.a.mdx
@@ -26,7 +26,7 @@ contract AmmFeeVerificationAssertion is Assertion {
     /// @notice Checks that the post-transaction fee is one of the allowed values.
     function assertFeeVerification() external view {
         address pool = ph.getAssertionAdopter();
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
 
         bool isStable = uint256(ph.loadStateAt(pool, STABLE_SLOT, postFork)) != 0;
         uint256 newFee = uint256(ph.loadStateAt(pool, FEE_SLOT, postFork));

--- a/snippets/ass14-fee-verification.a.mdx
+++ b/snippets/ass14-fee-verification.a.mdx
@@ -6,55 +6,35 @@ import {Assertion} from "credible-std/Assertion.sol";
 import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
-// Check that fee invariants are maintained
 contract AmmFeeVerificationAssertion is Assertion {
+    bytes32 internal constant FEE_SLOT = bytes32(uint256(1));
+    bytes32 internal constant STABLE_SLOT = bytes32(uint256(2));
+
+    uint256 private constant STABLE_POOL_FEE_1 = 1;
+    uint256 private constant STABLE_POOL_FEE_2 = 15;
+    uint256 private constant NON_STABLE_POOL_FEE_1 = 25;
+    uint256 private constant NON_STABLE_POOL_FEE_2 = 30;
+
     constructor() {
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
-    // Hardcoded whitelist of allowed fee values
-    uint256 private constant STABLE_POOL_FEE_1 = 1; // 0.1%
-    uint256 private constant STABLE_POOL_FEE_2 = 15; // 0.15%
-    uint256 private constant NON_STABLE_POOL_FEE_1 = 25; // 0.25%
-    uint256 private constant NON_STABLE_POOL_FEE_2 = 30; // 0.30%
-
     function triggers() external view override {
-        // Register trigger for changes to the fee storage slot
-        registerTxEndTrigger(this.assertFeeVerification.selector); // Assuming fee is in slot 1
+        registerTxEndTrigger(this.assertFeeVerification.selector);
     }
 
-    // Verify that any fee change is to an allowed value
+    /// @notice Checks that the post-transaction fee is one of the allowed values.
     function assertFeeVerification() external view {
-        // Get the assertion adopter address
-        IPool adopter = IPool(ph.getAssertionAdopter());
+        address pool = ph.getAssertionAdopter();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
-        // Get the new fee value and pool type
-        bool isStable = adopter.stable();
-        uint256 newFee = uint256(ph.loadStateAt(address(adopter), bytes32(uint256(1)), PhEvm.ForkId({forkType: 1, callIndex: 0})));
-
-        // Check if the new fee is in the whitelist
+        bool isStable = uint256(ph.loadStateAt(pool, STABLE_SLOT, postFork)) != 0;
+        uint256 newFee = uint256(ph.loadStateAt(pool, FEE_SLOT, postFork));
         bool isAllowed = isStable
             ? (newFee == STABLE_POOL_FEE_1 || newFee == STABLE_POOL_FEE_2)
             : (newFee == NON_STABLE_POOL_FEE_1 || newFee == NON_STABLE_POOL_FEE_2);
 
         require(isAllowed, "Fee change to unauthorized value");
-
-        // If the simple check passes, verify no unauthorized changes in the callstack
-        uint256[] memory changes = getStateChangesUint(address(adopter), bytes32(uint256(1)));
-
-        // Check each change against the whitelist
-        for (uint256 i = 0; i < changes.length; i++) {
-            isAllowed = isStable
-                ? (changes[i] == STABLE_POOL_FEE_1 || changes[i] == STABLE_POOL_FEE_2)
-                : (changes[i] == NON_STABLE_POOL_FEE_1 || changes[i] == NON_STABLE_POOL_FEE_2);
-            require(isAllowed, "Unauthorized fee change detected in callstack");
-        }
     }
-}
-
-// Aerodrome style interface
-interface IPool {
-    function fee() external view returns (uint256);
-    function stable() external view returns (bool);
 }
 ```

--- a/snippets/ass14-fee-verification.a.mdx
+++ b/snippets/ass14-fee-verification.a.mdx
@@ -3,10 +3,15 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 // Check that fee invariants are maintained
 contract AmmFeeVerificationAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     // Hardcoded whitelist of allowed fee values
     uint256 private constant STABLE_POOL_FEE_1 = 1; // 0.1%
     uint256 private constant STABLE_POOL_FEE_2 = 15; // 0.15%
@@ -15,7 +20,7 @@ contract AmmFeeVerificationAssertion is Assertion {
 
     function triggers() external view override {
         // Register trigger for changes to the fee storage slot
-        registerStorageChangeTrigger(this.assertFeeVerification.selector, bytes32(uint256(1))); // Assuming fee is in slot 1
+        registerTxEndTrigger(this.assertFeeVerification.selector); // Assuming fee is in slot 1
     }
 
     // Verify that any fee change is to an allowed value
@@ -25,7 +30,7 @@ contract AmmFeeVerificationAssertion is Assertion {
 
         // Get the new fee value and pool type
         bool isStable = adopter.stable();
-        uint256 newFee = uint256(ph.load(address(adopter), bytes32(uint256(1))));
+        uint256 newFee = uint256(ph.loadStateAt(address(adopter), bytes32(uint256(1)), PhEvm.ForkId({forkType: 1, callIndex: 0})));
 
         // Check if the new fee is in the whitelist
         bool isAllowed = isStable

--- a/snippets/ass15-price-within-ticks.a.mdx
+++ b/snippets/ass15-price-within-ticks.a.mdx
@@ -27,7 +27,7 @@ contract PriceWithinTicksAssertion is Assertion {
         IUniswapV3Pool adopter = IUniswapV3Pool(ph.getAssertionAdopter());
 
         // Get post-swap state
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
         (, int24 postTick,,,,,) = adopter.slot0();
         int24 spacing = adopter.tickSpacing();
 

--- a/snippets/ass15-price-within-ticks.a.mdx
+++ b/snippets/ass15-price-within-ticks.a.mdx
@@ -3,9 +3,14 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract PriceWithinTicksAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     // Uniswap V3 tick bounds
     int24 constant MIN_TICK = -887272;
     int24 constant MAX_TICK = 887272;
@@ -13,7 +18,7 @@ contract PriceWithinTicksAssertion is Assertion {
     function triggers() external view override {
         // Register trigger for changes to the tick storage slot
         // Assumes tick is stored in slot0 of the pool contract
-        registerStorageChangeTrigger(this.priceWithinTicks.selector, bytes32(uint256(0)));
+        registerTxEndTrigger(this.priceWithinTicks.selector);
     }
 
     // Check that the price is within the tick bounds and that the tick is divisible by the tick spacing
@@ -22,7 +27,7 @@ contract PriceWithinTicksAssertion is Assertion {
         IUniswapV3Pool adopter = IUniswapV3Pool(ph.getAssertionAdopter());
 
         // Get post-swap state
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         (, int24 postTick,,,,,) = adopter.slot0();
         int24 spacing = adopter.tickSpacing();
 

--- a/snippets/ass16-liquidation-health-factor.a.mdx
+++ b/snippets/ass16-liquidation-health-factor.a.mdx
@@ -3,16 +3,21 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract LiquidationHealthFactorAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     // Simple health factor constants (no scaling)
     uint256 constant LIQUIDATION_THRESHOLD = 100; // Below this = liquidatable
     uint256 constant MIN_HEALTH_FACTOR = 120; // Minimum safe health factor after liquidation
 
     function triggers() external view override {
         // Register trigger for liquidation function calls
-        registerCallTrigger(this.assertHealthFactor.selector, ILendingProtocol.liquidate.selector);
+        registerFnCallTrigger(this.assertHealthFactor.selector, ILendingProtocol.liquidate.selector);
     }
 
     // Check that liquidation can't happen if the position is healthy
@@ -37,12 +42,12 @@ contract LiquidationHealthFactorAssertion is Assertion {
             require(repaidDebt > 0, "Zero debt repaid");
 
             // Check health factor before liquidation
-            ph.forkPreCall(callInputs[i].id);
+            PhEvm.ForkId memory preCallFork = PhEvm.ForkId({forkType: 2, callIndex: callInputs[i].id});
             uint256 preHealthFactor = adopter.healthFactor(borrower);
             require(preHealthFactor <= LIQUIDATION_THRESHOLD, "Account not eligible for liquidation");
 
             // Check health factor after liquidation
-            ph.forkPostCall(callInputs[i].id);
+            PhEvm.ForkId memory postCallFork = PhEvm.ForkId({forkType: 3, callIndex: callInputs[i].id});
             uint256 postHealthFactor = adopter.healthFactor(borrower);
 
             // Verify the liquidation actually improved the position's health

--- a/snippets/ass17-panic-state-verificatoin.a.mdx
+++ b/snippets/ass17-panic-state-verificatoin.a.mdx
@@ -7,50 +7,32 @@ import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract EmergencyStateAssertion is Assertion {
+    bytes32 internal constant PAUSED_SLOT = bytes32(uint256(0));
+    bytes32 internal constant BALANCE_SLOT = bytes32(uint256(1));
+
     constructor() {
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
     function triggers() external view override {
-        // Register trigger for all function calls to ensure comprehensive coverage
-        registerFnCallTrigger(this.assertionPanickedCanOnlyDecreaseBalance.selector);
+        registerTxEndTrigger(this.assertionPanickedCanOnlyDecreaseBalance.selector);
     }
 
-    // Check that if the state is panicked that the pool balance can only decrease
-    // This ensures users can withdraw but prevents new deposits
-    function assertionPanickedCanOnlyDecreaseBalance() external {
-        // Get the assertion adopter address
-        IEmergencyPausable adopter = IEmergencyPausable(ph.getAssertionAdopter());
-
-        // Get pre-state values
+    /// @notice Checks that a paused protocol cannot increase its stored balance.
+    function assertionPanickedCanOnlyDecreaseBalance() external view {
+        address adopter = ph.getAssertionAdopter();
         PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        bool isPanicked = adopter.paused();
-        uint256 preBalance = adopter.balance();
-
-        // Get post-state values
         PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-        uint256 postBalance = adopter.balance();
 
-        // If protocol is paused, ensure balance can only decrease
-        if (isPanicked) {
-            require(postBalance <= preBalance, "Balance can only decrease when panicked");
-
-            // Additional check: verify no unauthorized state changes
-            uint256[] memory changes = getStateChangesUint(
-                address(adopter),
-                bytes32(uint256(1)) // Balance storage slot, change according to your contract
-            );
-
-            // Ensure all intermediate states maintain the decrease-only property
-            for (uint256 i = 0; i < changes.length; i++) {
-                require(changes[i] <= preBalance, "Unauthorized state change during pause");
-            }
+        bool wasPaused = uint256(ph.loadStateAt(adopter, PAUSED_SLOT, preFork)) != 0;
+        if (!wasPaused) {
+            return;
         }
-    }
-}
 
-interface IEmergencyPausable {
-    function paused() external view returns (bool);
-    function balance() external view returns (uint256);
+        uint256 preBalance = uint256(ph.loadStateAt(adopter, BALANCE_SLOT, preFork));
+        uint256 postBalance = uint256(ph.loadStateAt(adopter, BALANCE_SLOT, postFork));
+
+        require(postBalance <= preBalance, "Balance can only decrease when panicked");
+    }
 }
 ```

--- a/snippets/ass17-panic-state-verificatoin.a.mdx
+++ b/snippets/ass17-panic-state-verificatoin.a.mdx
@@ -21,8 +21,8 @@ contract EmergencyStateAssertion is Assertion {
     /// @notice Checks that a paused protocol cannot increase its stored balance.
     function assertionPanickedCanOnlyDecreaseBalance() external view {
         address adopter = ph.getAssertionAdopter();
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
+        PhEvm.ForkId memory postFork = _postTx();
 
         bool wasPaused = uint256(ph.loadStateAt(adopter, PAUSED_SLOT, preFork)) != 0;
         if (!wasPaused) {

--- a/snippets/ass17-panic-state-verificatoin.a.mdx
+++ b/snippets/ass17-panic-state-verificatoin.a.mdx
@@ -3,12 +3,17 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract EmergencyStateAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     function triggers() external view override {
         // Register trigger for all function calls to ensure comprehensive coverage
-        registerCallTrigger(this.assertionPanickedCanOnlyDecreaseBalance.selector);
+        registerFnCallTrigger(this.assertionPanickedCanOnlyDecreaseBalance.selector);
     }
 
     // Check that if the state is panicked that the pool balance can only decrease
@@ -18,12 +23,12 @@ contract EmergencyStateAssertion is Assertion {
         IEmergencyPausable adopter = IEmergencyPausable(ph.getAssertionAdopter());
 
         // Get pre-state values
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         bool isPanicked = adopter.paused();
         uint256 preBalance = adopter.balance();
 
         // Get post-state values
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 postBalance = adopter.balance();
 
         // If protocol is paused, ensure balance can only decrease

--- a/snippets/ass18-harvest-increases-balance.a.mdx
+++ b/snippets/ass18-harvest-increases-balance.a.mdx
@@ -6,58 +6,36 @@ import {Assertion} from "credible-std/Assertion.sol";
 import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
-// Inspired by https://github.com/beefyfinance/beefy-contracts/blob/master/forge/test/vault/ChainVaultsTest.t.sol#L77-L110
 contract BeefyHarvestAssertion is Assertion {
+    bytes32 internal constant BALANCE_SLOT = bytes32(uint256(0));
+    bytes32 internal constant PRICE_PER_SHARE_SLOT = bytes32(uint256(1));
+
     constructor() {
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
     function triggers() external view override {
-        // Register trigger for harvest function calls
         registerFnCallTrigger(this.assertionHarvestIncreasesBalance.selector, IBeefyVault.harvest.selector);
     }
 
-    // Assert that the balance of the vault doesn't decrease after a harvest
-    // and that the price per share doesn't decrease
-    function assertionHarvestIncreasesBalance() external {
-        // Get the assertion adopter address
-        IBeefyVault adopter = IBeefyVault(ph.getAssertionAdopter());
+    /// @notice Checks that a harvest does not reduce vault balance or price per share.
+    function assertionHarvestIncreasesBalance() external view {
+        address vault = ph.getAssertionAdopter();
+        PhEvm.TriggerContext memory ctx = ph.context();
+        PhEvm.ForkId memory preCall = PhEvm.ForkId({forkType: 2, callIndex: ctx.callStart});
+        PhEvm.ForkId memory postCall = PhEvm.ForkId({forkType: 3, callIndex: ctx.callEnd});
 
-        // Check pre-harvest state
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        uint256 preBalance = adopter.balance();
-        uint256 prePricePerShare = adopter.getPricePerFullShare();
+        uint256 preBalance = uint256(ph.loadStateAt(vault, BALANCE_SLOT, preCall));
+        uint256 postBalance = uint256(ph.loadStateAt(vault, BALANCE_SLOT, postCall));
+        uint256 prePricePerShare = uint256(ph.loadStateAt(vault, PRICE_PER_SHARE_SLOT, preCall));
+        uint256 postPricePerShare = uint256(ph.loadStateAt(vault, PRICE_PER_SHARE_SLOT, postCall));
 
-        // Check post-harvest state
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-        uint256 postBalance = adopter.balance();
-        uint256 postPricePerShare = adopter.getPricePerFullShare();
-
-        // Balance should not decrease after harvest (can stay the same if harvested recently)
         require(postBalance >= preBalance, "Harvest decreased balance");
-
-        // Price per share should increase or stay the same
         require(postPricePerShare >= prePricePerShare, "Price per share decreased after harvest");
-
-        // Get all state changes to the balance slot
-        uint256[] memory balanceChanges = getStateChangesUint(
-            address(adopter),
-            bytes32(uint256(0)) // First storage slot for balance
-        );
-
-        // Verify that all intermediate balance changes are valid
-        // Each balance change should be >= the previous balance in the sequence
-        uint256 lastBalance = preBalance;
-        for (uint256 i = 0; i < balanceChanges.length; i++) {
-            require(balanceChanges[i] >= lastBalance, "Invalid balance decrease detected during harvest");
-            lastBalance = balanceChanges[i];
-        }
     }
 }
 
 interface IBeefyVault {
-    function balance() external view returns (uint256);
-    function getPricePerFullShare() external view returns (uint256);
     function harvest(bool badHarvest) external;
 }
 ```

--- a/snippets/ass18-harvest-increases-balance.a.mdx
+++ b/snippets/ass18-harvest-increases-balance.a.mdx
@@ -3,13 +3,18 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 // Inspired by https://github.com/beefyfinance/beefy-contracts/blob/master/forge/test/vault/ChainVaultsTest.t.sol#L77-L110
 contract BeefyHarvestAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     function triggers() external view override {
         // Register trigger for harvest function calls
-        registerCallTrigger(this.assertionHarvestIncreasesBalance.selector, IBeefyVault.harvest.selector);
+        registerFnCallTrigger(this.assertionHarvestIncreasesBalance.selector, IBeefyVault.harvest.selector);
     }
 
     // Assert that the balance of the vault doesn't decrease after a harvest
@@ -19,12 +24,12 @@ contract BeefyHarvestAssertion is Assertion {
         IBeefyVault adopter = IBeefyVault(ph.getAssertionAdopter());
 
         // Check pre-harvest state
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 preBalance = adopter.balance();
         uint256 prePricePerShare = adopter.getPricePerFullShare();
 
         // Check post-harvest state
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 postBalance = adopter.balance();
         uint256 postPricePerShare = adopter.getPricePerFullShare();
 

--- a/snippets/ass19-tokens-borrowed-invariant.a.mdx
+++ b/snippets/ass19-tokens-borrowed-invariant.a.mdx
@@ -3,18 +3,23 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 // Assert that the total supply of assets is always greater than or equal to the total borrowed assets
 contract TokensBorrowedInvariant is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     // Use specific storage slots for the protocol
     bytes32 private constant TOTAL_SUPPLY_SLOT = bytes32(uint256(0)); // Slot 0
     bytes32 private constant TOTAL_BORROW_SLOT = bytes32(uint256(1)); // Slot 1
 
     function triggers() external view override {
         // Register triggers for changes to either storage slot with the main assertion function
-        registerStorageChangeTrigger(this.assertBorrowedInvariant.selector, TOTAL_SUPPLY_SLOT);
-        registerStorageChangeTrigger(this.assertBorrowedInvariant.selector, TOTAL_BORROW_SLOT);
+        registerTxEndTrigger(this.assertBorrowedInvariant.selector);
+        registerTxEndTrigger(this.assertBorrowedInvariant.selector);
     }
 
     // Check the invariant whenever supply or borrow values change
@@ -23,7 +28,7 @@ contract TokensBorrowedInvariant is Assertion {
         IMorpho adopter = IMorpho(ph.getAssertionAdopter());
 
         // Check the state after the transaction to ensure the invariant holds
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
         // Get the current protocol state
         uint256 totalSupplyAsset = adopter.totalSupplyAsset();

--- a/snippets/ass19-tokens-borrowed-invariant.a.mdx
+++ b/snippets/ass19-tokens-borrowed-invariant.a.mdx
@@ -21,7 +21,7 @@ contract TokensBorrowedInvariant is Assertion {
     /// @notice Checks that total supplied assets cover total borrowed assets after the transaction.
     function assertBorrowedInvariant() external view {
         address market = ph.getAssertionAdopter();
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
 
         uint256 totalSupplyAsset = uint256(ph.loadStateAt(market, TOTAL_SUPPLY_SLOT, postFork));
         uint256 totalBorrowedAsset = uint256(ph.loadStateAt(market, TOTAL_BORROW_SLOT, postFork));

--- a/snippets/ass19-tokens-borrowed-invariant.a.mdx
+++ b/snippets/ass19-tokens-borrowed-invariant.a.mdx
@@ -6,44 +6,30 @@ import {Assertion} from "credible-std/Assertion.sol";
 import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
-// Assert that the total supply of assets is always greater than or equal to the total borrowed assets
 contract TokensBorrowedInvariant is Assertion {
+    bytes32 internal constant TOTAL_SUPPLY_SLOT = bytes32(uint256(0));
+    bytes32 internal constant TOTAL_BORROW_SLOT = bytes32(uint256(1));
+
     constructor() {
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
-    // Use specific storage slots for the protocol
-    bytes32 private constant TOTAL_SUPPLY_SLOT = bytes32(uint256(0)); // Slot 0
-    bytes32 private constant TOTAL_BORROW_SLOT = bytes32(uint256(1)); // Slot 1
-
     function triggers() external view override {
-        // Register triggers for changes to either storage slot with the main assertion function
-        registerTxEndTrigger(this.assertBorrowedInvariant.selector);
         registerTxEndTrigger(this.assertBorrowedInvariant.selector);
     }
 
-    // Check the invariant whenever supply or borrow values change
-    function assertBorrowedInvariant() external {
-        // Get the assertion adopter address
-        IMorpho adopter = IMorpho(ph.getAssertionAdopter());
-
-        // Check the state after the transaction to ensure the invariant holds
+    /// @notice Checks that total supplied assets cover total borrowed assets after the transaction.
+    function assertBorrowedInvariant() external view {
+        address market = ph.getAssertionAdopter();
         PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
-        // Get the current protocol state
-        uint256 totalSupplyAsset = adopter.totalSupplyAsset();
-        uint256 totalBorrowedAsset = adopter.totalBorrowedAsset();
+        uint256 totalSupplyAsset = uint256(ph.loadStateAt(market, TOTAL_SUPPLY_SLOT, postFork));
+        uint256 totalBorrowedAsset = uint256(ph.loadStateAt(market, TOTAL_BORROW_SLOT, postFork));
 
-        // Ensure the core invariant is maintained
         require(
             totalSupplyAsset >= totalBorrowedAsset,
             "INVARIANT VIOLATION: Total supply of assets is less than total borrowed assets"
         );
     }
-}
-
-interface IMorpho {
-    function totalSupplyAsset() external view returns (uint256);
-    function totalBorrowedAsset() external view returns (uint256);
 }
 ```

--- a/snippets/ass2-erc4626-operations.a.mdx
+++ b/snippets/ass2-erc4626-operations.a.mdx
@@ -25,26 +25,31 @@ pragma solidity ^0.8.13;
  * changes, ensuring that all operations maintain the vault's accounting integrity.
  */
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {CoolVault} from "../../src/ass2-erc4626-operations.sol";
 import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract ERC4626OperationsAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     // The triggers function tells the Credible Layer which assertion functions to run
     function triggers() external view override {
         // Batch operations assertion - triggers on any of the four functions
-        registerCallTrigger(this.assertionBatchOperationsConsistency.selector, CoolVault.deposit.selector);
-        registerCallTrigger(this.assertionBatchOperationsConsistency.selector, CoolVault.mint.selector);
-        registerCallTrigger(this.assertionBatchOperationsConsistency.selector, CoolVault.withdraw.selector);
-        registerCallTrigger(this.assertionBatchOperationsConsistency.selector, CoolVault.redeem.selector);
+        registerFnCallTrigger(this.assertionBatchOperationsConsistency.selector, CoolVault.deposit.selector);
+        registerFnCallTrigger(this.assertionBatchOperationsConsistency.selector, CoolVault.mint.selector);
+        registerFnCallTrigger(this.assertionBatchOperationsConsistency.selector, CoolVault.withdraw.selector);
+        registerFnCallTrigger(this.assertionBatchOperationsConsistency.selector, CoolVault.redeem.selector);
 
         // Deposit-specific assertions
-        registerCallTrigger(this.assertionDepositIncreasesBalance.selector, CoolVault.deposit.selector);
-        registerCallTrigger(this.assertionDepositerSharesIncreases.selector, CoolVault.deposit.selector);
+        registerFnCallTrigger(this.assertionDepositIncreasesBalance.selector, CoolVault.deposit.selector);
+        registerFnCallTrigger(this.assertionDepositerSharesIncreases.selector, CoolVault.deposit.selector);
 
         // Base invariant assertion - triggers on storage changes
-        registerStorageChangeTrigger(this.assertionVaultAlwaysAccumulatesAssets.selector, bytes32(uint256(2)));
+        registerTxEndTrigger(this.assertionVaultAlwaysAccumulatesAssets.selector);
     }
 
     /**
@@ -97,11 +102,11 @@ contract ERC4626OperationsAssertion is Assertion {
             totalAssetsRemoved += adopter.previewRedeem(shares);
         }
 
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 preVaultAssets = adopter.totalAssets();
         uint256 preVaultSupply = adopter.totalSupply();
 
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 postVaultAssets = adopter.totalAssets();
         uint256 postVaultSupply = adopter.totalSupply();
 
@@ -133,13 +138,13 @@ contract ERC4626OperationsAssertion is Assertion {
             (uint256 assets, address receiver) = abi.decode(inputs[i].input, (uint256, address));
 
             // Check pre-state
-            ph.forkPreTx();
+            PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
             uint256 vaultAssetPreBalance = adopter.totalAssets();
             uint256 userSharesPreBalance = adopter.balanceOf(receiver);
             uint256 expectedShares = adopter.previewDeposit(assets);
 
             // Check post-state
-            ph.forkPostTx();
+            PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
             uint256 vaultAssetPostBalance = adopter.totalAssets();
             uint256 userSharesPostBalance = adopter.balanceOf(receiver);
 
@@ -168,13 +173,13 @@ contract ERC4626OperationsAssertion is Assertion {
         PhEvm.CallInputs[] memory inputs = ph.getCallInputs(address(adopter), adopter.deposit.selector);
 
         for (uint256 i = 0; i < inputs.length; i++) {
-            ph.forkPreTx();
+            PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
             (uint256 assets,) = abi.decode(inputs[i].input, (uint256, address));
             uint256 previewPreAssets = adopter.previewDeposit(assets);
             address depositer = inputs[0].caller;
             uint256 preShares = adopter.balanceOf(depositer);
 
-            ph.forkPostTx();
+            PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
             uint256 postShares = adopter.balanceOf(depositer);
 
@@ -193,7 +198,7 @@ contract ERC4626OperationsAssertion is Assertion {
         // Get the assertion adopter address
         CoolVault adopter = CoolVault(ph.getAssertionAdopter());
 
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
         uint256 vaultAssetPostBalance = adopter.totalAssets();
         uint256 vaultSharesPostBalance = adopter.balanceOf(address(adopter));

--- a/snippets/ass2-erc4626-operations.a.mdx
+++ b/snippets/ass2-erc4626-operations.a.mdx
@@ -102,11 +102,11 @@ contract ERC4626OperationsAssertion is Assertion {
             totalAssetsRemoved += adopter.previewRedeem(shares);
         }
 
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
         uint256 preVaultAssets = adopter.totalAssets();
         uint256 preVaultSupply = adopter.totalSupply();
 
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
         uint256 postVaultAssets = adopter.totalAssets();
         uint256 postVaultSupply = adopter.totalSupply();
 
@@ -138,13 +138,13 @@ contract ERC4626OperationsAssertion is Assertion {
             (uint256 assets, address receiver) = abi.decode(inputs[i].input, (uint256, address));
 
             // Check pre-state
-            PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+            PhEvm.ForkId memory preFork = _preTx();
             uint256 vaultAssetPreBalance = adopter.totalAssets();
             uint256 userSharesPreBalance = adopter.balanceOf(receiver);
             uint256 expectedShares = adopter.previewDeposit(assets);
 
             // Check post-state
-            PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+            PhEvm.ForkId memory postFork = _postTx();
             uint256 vaultAssetPostBalance = adopter.totalAssets();
             uint256 userSharesPostBalance = adopter.balanceOf(receiver);
 
@@ -173,13 +173,13 @@ contract ERC4626OperationsAssertion is Assertion {
         PhEvm.CallInputs[] memory inputs = ph.getCallInputs(address(adopter), adopter.deposit.selector);
 
         for (uint256 i = 0; i < inputs.length; i++) {
-            PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+            PhEvm.ForkId memory preFork = _preTx();
             (uint256 assets,) = abi.decode(inputs[i].input, (uint256, address));
             uint256 previewPreAssets = adopter.previewDeposit(assets);
             address depositer = inputs[0].caller;
             uint256 preShares = adopter.balanceOf(depositer);
 
-            PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+            PhEvm.ForkId memory postFork = _postTx();
 
             uint256 postShares = adopter.balanceOf(depositer);
 
@@ -198,7 +198,7 @@ contract ERC4626OperationsAssertion is Assertion {
         // Get the assertion adopter address
         CoolVault adopter = CoolVault(ph.getAssertionAdopter());
 
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
 
         uint256 vaultAssetPostBalance = adopter.totalAssets();
         uint256 vaultSharesPostBalance = adopter.balanceOf(address(adopter));

--- a/snippets/ass20-erc20-drain.a.mdx
+++ b/snippets/ass20-erc20-drain.a.mdx
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract ERC20DrainAssertion is Assertion {
@@ -16,6 +17,7 @@ contract ERC20DrainAssertion is Assertion {
     address public tokenAddress;
 
     constructor(address tokenAddress_) {
+        registerAssertionSpec(AssertionSpec.Reshiram);
         tokenAddress = tokenAddress_;
     }
 
@@ -23,7 +25,7 @@ contract ERC20DrainAssertion is Assertion {
         // This assertion doesn't need specific function triggers since it monitors
         // the overall balance change regardless of which function caused it
         // We register a generic trigger that will run after every transaction
-        registerCallTrigger(this.assertERC20Drain.selector);
+        registerFnCallTrigger(this.assertERC20Drain.selector);
     }
 
     /// @notice Checks that the token balance doesn't decrease by more than MAX_DRAIN_PERCENTAGE_BPS in a single transaction
@@ -33,11 +35,11 @@ contract ERC20DrainAssertion is Assertion {
         ITokenVault protocol = ITokenVault(ph.getAssertionAdopter());
 
         // Get token balance before the transaction
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 preBalance = IERC20(tokenAddress).balanceOf(address(protocol));
 
         // Get token balance after the transaction
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 postBalance = IERC20(tokenAddress).balanceOf(address(protocol));
 
         // If balance decreased, check if the decrease exceeds our threshold

--- a/snippets/ass20-erc20-drain.a.mdx
+++ b/snippets/ass20-erc20-drain.a.mdx
@@ -6,64 +6,35 @@ import {Assertion} from "credible-std/Assertion.sol";
 import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
-contract ERC20DrainAssertion is Assertion {
-    // Maximum percentage of token balance that can be withdrawn in a single tx (in basis points)
-    // 1000 basis points = 10%
-    uint256 public constant MAX_DRAIN_PERCENTAGE_BPS = 1000;
+contract ERC20CumulativeOutflowBreakerAssertion is Assertion {
+    address public immutable monitoredToken;
+    uint256 public immutable outflowThresholdBps;
+    uint256 public immutable outflowWindowDuration;
 
-    // Denominator for basis points calculation
-    uint256 public constant BPS_DENOMINATOR = 10000;
-
-    address public tokenAddress;
-
-    constructor(address tokenAddress_) {
+    constructor(address monitoredToken_, uint256 outflowThresholdBps_, uint256 outflowWindowDuration_) {
         registerAssertionSpec(AssertionSpec.Reshiram);
-        tokenAddress = tokenAddress_;
+
+        monitoredToken = monitoredToken_;
+        outflowThresholdBps = outflowThresholdBps_;
+        outflowWindowDuration = outflowWindowDuration_;
     }
 
     function triggers() external view override {
-        // This assertion doesn't need specific function triggers since it monitors
-        // the overall balance change regardless of which function caused it
-        // We register a generic trigger that will run after every transaction
-        registerFnCallTrigger(this.assertERC20Drain.selector);
+        watchCumulativeOutflow(
+            monitoredToken,
+            outflowThresholdBps,
+            outflowWindowDuration,
+            this.assertCumulativeOutflow.selector
+        );
     }
 
-    /// @notice Checks that the token balance doesn't decrease by more than MAX_DRAIN_PERCENTAGE_BPS in a single transaction
-    /// @dev This assertion captures state before and after the transaction to detect excessive token outflows
-    function assertERC20Drain() external {
-        // Get the assertion adopter address (this is the protocol contract)
-        ITokenVault protocol = ITokenVault(ph.getAssertionAdopter());
+    /// @notice Reverts when cumulative token outflow breaches the rolling-window limit.
+    /// @dev The Reshiram trigger tracks the window and calls this function only after breach.
+    function assertCumulativeOutflow() external view {
+        PhEvm.OutflowContext memory ctx = ph.outflowContext();
+        require(ctx.token == monitoredToken, "ERC20Outflow: wrong token context");
 
-        // Get token balance before the transaction
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        uint256 preBalance = IERC20(tokenAddress).balanceOf(address(protocol));
-
-        // Get token balance after the transaction
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-        uint256 postBalance = IERC20(tokenAddress).balanceOf(address(protocol));
-
-        // If balance decreased, check if the decrease exceeds our threshold
-        if (preBalance > postBalance) {
-            uint256 drainAmount = preBalance - postBalance;
-
-            // Calculate maximum allowed drain amount (e.g., 10% of pre-balance)
-            uint256 maxAllowedDrainAmount = (preBalance * MAX_DRAIN_PERCENTAGE_BPS) / BPS_DENOMINATOR;
-
-            // Revert if the drain amount exceeds the allowed percentage
-            require(
-                drainAmount <= maxAllowedDrainAmount, "ERC20Drain: Token outflow exceeds maximum allowed percentage"
-            );
-        }
+        revert("ERC20Outflow: cumulative outflow breaker tripped");
     }
-}
-
-interface IERC20 {
-    function balanceOf(address account) external view returns (uint256);
-}
-
-interface ITokenVault {
-    function withdraw(address recipient, uint256 amount) external;
-    function getBalance() external view returns (uint256);
-    function deposit(uint256 amount) external;
 }
 ```

--- a/snippets/ass21-ether-drain.a.mdx
+++ b/snippets/ass21-ether-drain.a.mdx
@@ -3,15 +3,20 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract EtherDrainAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     // Maximum percentage of ETH that can be drained in a single transaction (10% by default)
     uint256 public constant MAX_DRAIN_PERCENTAGE = 10;
 
     function triggers() external view override {
         // Register a trigger that activates when the ETH balance of the monitored contract changes
-        registerBalanceChangeTrigger(this.assertionEtherDrain.selector);
+        registerTxEndTrigger(this.assertionEtherDrain.selector);
     }
 
     // Combined assertion for ETH drain with whitelist logic
@@ -20,11 +25,11 @@ contract EtherDrainAssertion is Assertion {
         address exampleContract = ph.getAssertionAdopter();
 
         // Capture the ETH balance before transaction execution
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 preBalance = address(exampleContract).balance;
 
         // Capture the ETH balance after transaction execution
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 postBalance = address(exampleContract).balance;
 
         // Only check for drainage (we don't care about ETH being added)

--- a/snippets/ass21-ether-drain.a.mdx
+++ b/snippets/ass21-ether-drain.a.mdx
@@ -25,11 +25,11 @@ contract EtherDrainAssertion is Assertion {
         address exampleContract = ph.getAssertionAdopter();
 
         // Capture the ETH balance before transaction execution
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
         uint256 preBalance = address(exampleContract).balance;
 
         // Capture the ETH balance after transaction execution
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
         uint256 postBalance = address(exampleContract).balance;
 
         // Only check for drainage (we don't care about ETH being added)

--- a/snippets/ass22-erc20-inflow-breaker.a.mdx
+++ b/snippets/ass22-erc20-inflow-breaker.a.mdx
@@ -1,0 +1,40 @@
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
+import {PhEvm} from "credible-std/PhEvm.sol";
+
+contract ERC20CumulativeInflowBreakerAssertion is Assertion {
+    address public immutable monitoredToken;
+    uint256 public immutable inflowThresholdBps;
+    uint256 public immutable inflowWindowDuration;
+
+    constructor(address monitoredToken_, uint256 inflowThresholdBps_, uint256 inflowWindowDuration_) {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+
+        monitoredToken = monitoredToken_;
+        inflowThresholdBps = inflowThresholdBps_;
+        inflowWindowDuration = inflowWindowDuration_;
+    }
+
+    function triggers() external view override {
+        watchCumulativeInflow(
+            monitoredToken,
+            inflowThresholdBps,
+            inflowWindowDuration,
+            this.assertCumulativeInflow.selector
+        );
+    }
+
+    /// @notice Reverts when cumulative token inflow breaches the rolling-window limit.
+    /// @dev The Reshiram trigger tracks the window and calls this function only after breach.
+    function assertCumulativeInflow() external view {
+        PhEvm.InflowContext memory ctx = ph.inflowContext();
+        require(ctx.token == monitoredToken, "ERC20Inflow: wrong token context");
+
+        revert("ERC20Inflow: cumulative inflow breaker tripped");
+    }
+}
+```

--- a/snippets/ass28-intra-tx-oracle-deviation.a.mdx
+++ b/snippets/ass28-intra-tx-oracle-deviation.a.mdx
@@ -3,15 +3,20 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract IntraTxOracleDeviationAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     // Maximum allowed price deviation (10% by default)
     uint256 public constant MAX_DEVIATION_PERCENTAGE = 10;
 
     function triggers() external view override {
         // Register trigger for oracle price update calls
-        registerCallTrigger(this.assertOracleDeviation.selector, IOracle.updatePrice.selector);
+        registerFnCallTrigger(this.assertOracleDeviation.selector, IOracle.updatePrice.selector);
     }
 
     // Check that price updates don't deviate more than the allowed percentage
@@ -21,7 +26,7 @@ contract IntraTxOracleDeviationAssertion is Assertion {
         IOracle adopter = IOracle(ph.getAssertionAdopter());
 
         // Start with a simple check comparing pre and post state
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 prePrice = adopter.price();
 
         // Calculate allowed deviation thresholds (10% by default)
@@ -29,7 +34,7 @@ contract IntraTxOracleDeviationAssertion is Assertion {
         uint256 minAllowedPrice = (prePrice * (100 - MAX_DEVIATION_PERCENTAGE)) / 100;
 
         // First check post-state price
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         uint256 postPrice = adopter.price();
 
         // Verify post-state price is within allowed deviation from initial price
@@ -44,7 +49,7 @@ contract IntraTxOracleDeviationAssertion is Assertion {
 
         // Check each price update to ensure none deviate more than allowed from initial price
         for (uint256 i = 0; i < priceUpdates.length; i++) {
-            ph.forkPostCall(priceUpdates[i].id);
+            PhEvm.ForkId memory postCallFork = PhEvm.ForkId({forkType: 3, callIndex: priceUpdates[i].id});
 
             // Call the price function at the given frame in the call stack
             uint256 updatedPrice = adopter.price();

--- a/snippets/ass28-intra-tx-oracle-deviation.a.mdx
+++ b/snippets/ass28-intra-tx-oracle-deviation.a.mdx
@@ -26,7 +26,7 @@ contract IntraTxOracleDeviationAssertion is Assertion {
         IOracle adopter = IOracle(ph.getAssertionAdopter());
 
         // Start with a simple check comparing pre and post state
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
         uint256 prePrice = adopter.price();
 
         // Calculate allowed deviation thresholds (10% by default)
@@ -34,7 +34,7 @@ contract IntraTxOracleDeviationAssertion is Assertion {
         uint256 minAllowedPrice = (prePrice * (100 - MAX_DEVIATION_PERCENTAGE)) / 100;
 
         // First check post-state price
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory postFork = _postTx();
         uint256 postPrice = adopter.price();
 
         // Verify post-state price is within allowed deviation from initial price

--- a/snippets/ass4-kyc-whitelist.a.mdx
+++ b/snippets/ass4-kyc-whitelist.a.mdx
@@ -8,43 +8,39 @@ import {PhEvm} from "credible-std/PhEvm.sol";
 import {OnlyAccreditedCanMint} from "../../src/ass4-only-accredited-can-mint.sol";
 import {AccreditedInvestorRegistry} from "../../src/AccreditedInvestorRegistry.sol";
 
-/// @notice Assertions ensuring OnlyAccreditedCanMint restricts privileged actions to accredited callers
 contract OnlyAccreditedCanMintAssertion is Assertion {
     AccreditedInvestorRegistry public immutable registry;
 
-    constructor(address tokenAddress) {
+    constructor(address registry_) {
         registerAssertionSpec(AssertionSpec.Reshiram);
-        registry = AccreditedInvestorRegistry(tokenAddress);
+        registry = AccreditedInvestorRegistry(registry_);
     }
 
-    // register the functions that will be called and used by the assertion functions below
     function triggers() external view override {
         registerFnCallTrigger(this.assertOnlyAccreditedMint.selector, OnlyAccreditedCanMint.mint.selector);
         registerFnCallTrigger(this.assertOnlyAccreditedTransfer.selector, OnlyAccreditedCanMint.transfer.selector);
     }
 
-    /// @notice When msg.sender hits mint, if they are not in the registry, theycannot mint tokens
-    function assertOnlyAccreditedMint() external {
-        OnlyAccreditedCanMint token = OnlyAccreditedCanMint(ph.getAssertionAdopter());
+    /// @notice Checks that the caller of `mint` is accredited.
+    function assertOnlyAccreditedMint() external view {
+        _assertMatchingCallersAccredited(OnlyAccreditedCanMint.mint.selector);
+    }
 
-        PhEvm.CallInputs[] memory calls = ph.getCallInputs(address(token), OnlyAccreditedCanMint.mint.selector);
+    /// @notice Checks that the caller of `transfer` is accredited.
+    function assertOnlyAccreditedTransfer() external view {
+        _assertMatchingCallersAccredited(OnlyAccreditedCanMint.transfer.selector);
+    }
 
+    function _assertMatchingCallersAccredited(bytes4 selector) internal view {
+        PhEvm.TriggerCall[] memory calls = ph.matchingCalls(ph.getAssertionAdopter(), selector, _successfulCalls(), 32);
         for (uint256 i = 0; i < calls.length; i++) {
-            // Bundle the accreditation check into any call
             require(registry.isAccredited(calls[i].caller), "caller is not accredited");
         }
     }
 
-    /// @notice Ensure that non-accredited callers cannot transfer tokens
-    function assertOnlyAccreditedTransfer() external {
-        OnlyAccreditedCanMint token = OnlyAccreditedCanMint(ph.getAssertionAdopter());
-
-        PhEvm.CallInputs[] memory calls = ph.getCallInputs(address(token), OnlyAccreditedCanMint.transfer.selector);
-
-        for (uint256 i = 0; i < calls.length; i++) {
-            // Bundle the accreditation check into any call
-            require(registry.isAccredited(calls[i].caller), "caller is not accredited");
-        }
+    function _successfulCalls() internal pure returns (PhEvm.CallFilter memory filter) {
+        filter.callType = 1;
+        filter.successOnly = true;
     }
 }
 ```

--- a/snippets/ass4-kyc-whitelist.a.mdx
+++ b/snippets/ass4-kyc-whitelist.a.mdx
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 import {OnlyAccreditedCanMint} from "../../src/ass4-only-accredited-can-mint.sol";
 import {AccreditedInvestorRegistry} from "../../src/AccreditedInvestorRegistry.sol";
@@ -12,13 +13,14 @@ contract OnlyAccreditedCanMintAssertion is Assertion {
     AccreditedInvestorRegistry public immutable registry;
 
     constructor(address tokenAddress) {
+        registerAssertionSpec(AssertionSpec.Reshiram);
         registry = AccreditedInvestorRegistry(tokenAddress);
     }
 
     // register the functions that will be called and used by the assertion functions below
     function triggers() external view override {
-        registerCallTrigger(this.assertOnlyAccreditedMint.selector, OnlyAccreditedCanMint.mint.selector);
-        registerCallTrigger(this.assertOnlyAccreditedTransfer.selector, OnlyAccreditedCanMint.transfer.selector);
+        registerFnCallTrigger(this.assertOnlyAccreditedMint.selector, OnlyAccreditedCanMint.mint.selector);
+        registerFnCallTrigger(this.assertOnlyAccreditedTransfer.selector, OnlyAccreditedCanMint.transfer.selector);
     }
 
     /// @notice When msg.sender hits mint, if they are not in the registry, theycannot mint tokens

--- a/snippets/ass5-owner-change.a.mdx
+++ b/snippets/ass5-owner-change.a.mdx
@@ -7,77 +7,44 @@ import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract OwnerChangeAssertion is Assertion {
+    bytes32 internal constant OWNER_SLOT = bytes32(uint256(0));
+    bytes32 internal constant ADMIN_SLOT = bytes32(uint256(1));
+
     constructor() {
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
     function triggers() external view override {
-        // Register triggers for changes to both owner and admin storage slots
         registerTxEndTrigger(this.assertionOwnerChange.selector);
         registerTxEndTrigger(this.assertionAdminChange.selector);
     }
 
-    // Assert that the owner address doesn't change during the state transition
-    function assertionOwnerChange() external {
-        // Get the assertion adopter address
-        IOwnership adopter = IOwnership(ph.getAssertionAdopter());
-
-        // Get pre-state owner
+    /// @notice Checks that the owner slot is unchanged across the transaction.
+    function assertionOwnerChange() external view {
+        address adopter = ph.getAssertionAdopter();
         PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        address preOwner = adopter.owner();
-
-        // Get post-state owner
         PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-        address postOwner = adopter.owner();
 
-        // Verify owner hasn't changed after the transaction
-        // Fail early if the owner has changed
+        address preOwner = _loadAddressAt(adopter, OWNER_SLOT, preFork);
+        address postOwner = _loadAddressAt(adopter, OWNER_SLOT, postFork);
+
         require(preOwner == postOwner, "Owner changed");
-
-        // Get all state changes for the owner slot
-        // This checks if the owner address has changed throughout the callstack
-        address[] memory changes = getStateChangesAddress(
-            address(adopter),
-            bytes32(uint256(0)) // First storage slot for owner address
-        );
-
-        // Additional check: verify no changes take place in the owner slot throughout the callstack
-        for (uint256 i = 0; i < changes.length; i++) {
-            require(changes[i] == preOwner, "Unauthorized owner change detected");
-        }
     }
 
-    // Assert that the admin address doesn't change during the state transition
-    function assertionAdminChange() external {
-        // Get the assertion adopter address
-        IOwnership adopter = IOwnership(ph.getAssertionAdopter());
-
-        // Get pre-state admin
+    /// @notice Checks that the admin slot is unchanged across the transaction.
+    function assertionAdminChange() external view {
+        address adopter = ph.getAssertionAdopter();
         PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        address preAdmin = adopter.admin();
-
-        // Get post-state admin
         PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-        address postAdmin = adopter.admin();
 
-        // Get all state changes for the admin slot
-        address[] memory changes = getStateChangesAddress(
-            address(adopter),
-            bytes32(uint256(1)) // Second storage slot for admin address
-        );
+        address preAdmin = _loadAddressAt(adopter, ADMIN_SLOT, preFork);
+        address postAdmin = _loadAddressAt(adopter, ADMIN_SLOT, postFork);
 
-        // Verify admin hasn't changed after the transaction
         require(preAdmin == postAdmin, "Admin changed");
-
-        // Additional check: verify no changes take place in the admin slot throughout the callstack
-        for (uint256 i = 0; i < changes.length; i++) {
-            require(changes[i] == preAdmin, "Unauthorized admin change detected");
-        }
     }
-}
 
-interface IOwnership {
-    function owner() external view returns (address);
-    function admin() external view returns (address);
+    function _loadAddressAt(address target, bytes32 slot, PhEvm.ForkId memory fork) internal view returns (address) {
+        return address(uint160(uint256(ph.loadStateAt(target, slot, fork))));
+    }
 }
 ```

--- a/snippets/ass5-owner-change.a.mdx
+++ b/snippets/ass5-owner-change.a.mdx
@@ -22,8 +22,8 @@ contract OwnerChangeAssertion is Assertion {
     /// @notice Checks that the owner slot is unchanged across the transaction.
     function assertionOwnerChange() external view {
         address adopter = ph.getAssertionAdopter();
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
+        PhEvm.ForkId memory postFork = _postTx();
 
         address preOwner = _loadAddressAt(adopter, OWNER_SLOT, preFork);
         address postOwner = _loadAddressAt(adopter, OWNER_SLOT, postFork);
@@ -34,8 +34,8 @@ contract OwnerChangeAssertion is Assertion {
     /// @notice Checks that the admin slot is unchanged across the transaction.
     function assertionAdminChange() external view {
         address adopter = ph.getAssertionAdopter();
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
+        PhEvm.ForkId memory postFork = _postTx();
 
         address preAdmin = _loadAddressAt(adopter, ADMIN_SLOT, preFork);
         address postAdmin = _loadAddressAt(adopter, ADMIN_SLOT, postFork);

--- a/snippets/ass5-owner-change.a.mdx
+++ b/snippets/ass5-owner-change.a.mdx
@@ -3,13 +3,18 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract OwnerChangeAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     function triggers() external view override {
         // Register triggers for changes to both owner and admin storage slots
-        registerStorageChangeTrigger(this.assertionOwnerChange.selector, bytes32(uint256(0)));
-        registerStorageChangeTrigger(this.assertionAdminChange.selector, bytes32(uint256(1)));
+        registerTxEndTrigger(this.assertionOwnerChange.selector);
+        registerTxEndTrigger(this.assertionAdminChange.selector);
     }
 
     // Assert that the owner address doesn't change during the state transition
@@ -18,11 +23,11 @@ contract OwnerChangeAssertion is Assertion {
         IOwnership adopter = IOwnership(ph.getAssertionAdopter());
 
         // Get pre-state owner
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         address preOwner = adopter.owner();
 
         // Get post-state owner
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         address postOwner = adopter.owner();
 
         // Verify owner hasn't changed after the transaction
@@ -48,11 +53,11 @@ contract OwnerChangeAssertion is Assertion {
         IOwnership adopter = IOwnership(ph.getAssertionAdopter());
 
         // Get pre-state admin
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         address preAdmin = adopter.admin();
 
         // Get post-state admin
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         address postAdmin = adopter.admin();
 
         // Get all state changes for the admin slot

--- a/snippets/ass6-constant-product.a.mdx
+++ b/snippets/ass6-constant-product.a.mdx
@@ -21,8 +21,8 @@ contract ConstantProductAssertion is Assertion {
     /// @notice Checks that the pool's stored reserve product is not reduced by the transaction.
     function assertionConstantProduct() external view {
         address pool = ph.getAssertionAdopter();
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
+        PhEvm.ForkId memory postFork = _postTx();
 
         uint256 reserve0Pre = uint256(ph.loadStateAt(pool, RESERVE0_SLOT, preFork));
         uint256 reserve1Pre = uint256(ph.loadStateAt(pool, RESERVE1_SLOT, preFork));

--- a/snippets/ass6-constant-product.a.mdx
+++ b/snippets/ass6-constant-product.a.mdx
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 // Aerodrome style pool interface
 
@@ -11,11 +12,15 @@ interface IAmm {
 }
 
 contract ConstantProductAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     function triggers() external view override {
         // Register triggers for both reserve slots for each assertion
         // This ensures we catch any modifications to either reserve
-        registerStorageChangeTrigger(this.assertionConstantProduct.selector, bytes32(uint256(0)));
-        registerStorageChangeTrigger(this.assertionConstantProduct.selector, bytes32(uint256(1)));
+        registerTxEndTrigger(this.assertionConstantProduct.selector);
+        registerTxEndTrigger(this.assertionConstantProduct.selector);
     }
 
     // Assert that the constant product (k = x * y) invariant is maintained
@@ -36,12 +41,12 @@ contract ConstantProductAssertion is Assertion {
         IAmm adopter = IAmm(ph.getAssertionAdopter());
 
         // Get pre-state reserves and calculate initial k
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         (uint256 reserve0Pre, uint256 reserve1Pre) = adopter.getReserves();
         uint256 kPre = reserve0Pre * reserve1Pre;
 
         // Get post-state reserves and calculate final k
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
         (uint256 reserve0Post, uint256 reserve1Post) = adopter.getReserves();
         uint256 kPost = reserve0Post * reserve1Post;
 

--- a/snippets/ass6-constant-product.a.mdx
+++ b/snippets/ass6-constant-product.a.mdx
@@ -5,53 +5,31 @@ pragma solidity ^0.8.13;
 import {Assertion} from "credible-std/Assertion.sol";
 import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
-// Aerodrome style pool interface
-
-interface IAmm {
-    function getReserves() external view returns (uint256, uint256);
-}
 
 contract ConstantProductAssertion is Assertion {
+    bytes32 internal constant RESERVE0_SLOT = bytes32(uint256(0));
+    bytes32 internal constant RESERVE1_SLOT = bytes32(uint256(1));
+
     constructor() {
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
     function triggers() external view override {
-        // Register triggers for both reserve slots for each assertion
-        // This ensures we catch any modifications to either reserve
-        registerTxEndTrigger(this.assertionConstantProduct.selector);
         registerTxEndTrigger(this.assertionConstantProduct.selector);
     }
 
-    // Assert that the constant product (k = x * y) invariant is maintained
-    // This is done by comparing the pre-state and post-state values
-    //
-    // NOTE: Due to current limitations in getStateChanges, there are no guarantees
-    // regarding timing when comparing values from two stateChanges arrays throughout the callstack.
-    // An ideal solution in the future would allow for comparing values at any given
-    // point in time during the callstack, thus making it possible to prevent
-    // potential intra-transaction manipulations of the constant product invariant.
-    //
-    // For example, a malicious actor could temporarily manipulate the reserves
-    // to violate the invariant during the transaction, then restore them before
-    // the end of the transaction to avoid detection in a pre/post comparison.
-    function assertionConstantProduct() external {
-        // TOOD: Use new call frame forking to fix this assertion
-        // Get the assertion adopter address
-        IAmm adopter = IAmm(ph.getAssertionAdopter());
-
-        // Get pre-state reserves and calculate initial k
+    /// @notice Checks that the pool's stored reserve product is not reduced by the transaction.
+    function assertionConstantProduct() external view {
+        address pool = ph.getAssertionAdopter();
         PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        (uint256 reserve0Pre, uint256 reserve1Pre) = adopter.getReserves();
-        uint256 kPre = reserve0Pre * reserve1Pre;
-
-        // Get post-state reserves and calculate final k
         PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
-        (uint256 reserve0Post, uint256 reserve1Post) = adopter.getReserves();
-        uint256 kPost = reserve0Post * reserve1Post;
 
-        // Verify the final state maintains the constant product
-        require(kPre == kPost, "Constant product invariant violated");
+        uint256 reserve0Pre = uint256(ph.loadStateAt(pool, RESERVE0_SLOT, preFork));
+        uint256 reserve1Pre = uint256(ph.loadStateAt(pool, RESERVE1_SLOT, preFork));
+        uint256 reserve0Post = uint256(ph.loadStateAt(pool, RESERVE0_SLOT, postFork));
+        uint256 reserve1Post = uint256(ph.loadStateAt(pool, RESERVE1_SLOT, postFork));
+
+        require(reserve0Post * reserve1Post >= reserve0Pre * reserve1Pre, "Constant product invariant reduced");
     }
 }
 ```

--- a/snippets/ass7-lending-health-factor.a.mdx
+++ b/snippets/ass7-lending-health-factor.a.mdx
@@ -3,15 +3,20 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract LendingHealthFactorAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     function triggers() external view override {
         // Register triggers for each function that should maintain healthy positions
-        registerCallTrigger(this.assertionSupply.selector, IMorpho.supply.selector);
-        registerCallTrigger(this.assertionBorrow.selector, IMorpho.borrow.selector);
-        registerCallTrigger(this.assertionWithdraw.selector, IMorpho.withdraw.selector);
-        registerCallTrigger(this.assertionRepay.selector, IMorpho.repay.selector);
+        registerFnCallTrigger(this.assertionSupply.selector, IMorpho.supply.selector);
+        registerFnCallTrigger(this.assertionBorrow.selector, IMorpho.borrow.selector);
+        registerFnCallTrigger(this.assertionWithdraw.selector, IMorpho.withdraw.selector);
+        registerFnCallTrigger(this.assertionRepay.selector, IMorpho.repay.selector);
     }
 
     // Check that supply operation maintains healthy positions

--- a/snippets/ass7-lending-health-factor.a.mdx
+++ b/snippets/ass7-lending-health-factor.a.mdx
@@ -7,105 +7,57 @@ import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract LendingHealthFactorAssertion is Assertion {
+    bytes32 internal constant HEALTH_FACTOR_SLOT = bytes32(uint256(0));
+    uint256 internal constant MIN_HEALTH_FACTOR = 1e18;
+
     constructor() {
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
     function triggers() external view override {
-        // Register triggers for each function that should maintain healthy positions
-        registerFnCallTrigger(this.assertionSupply.selector, IMorpho.supply.selector);
-        registerFnCallTrigger(this.assertionBorrow.selector, IMorpho.borrow.selector);
-        registerFnCallTrigger(this.assertionWithdraw.selector, IMorpho.withdraw.selector);
-        registerFnCallTrigger(this.assertionRepay.selector, IMorpho.repay.selector);
+        registerFnCallTrigger(this.assertionOperationSafety.selector, IMorpho.supply.selector);
+        registerFnCallTrigger(this.assertionOperationSafety.selector, IMorpho.borrow.selector);
+        registerFnCallTrigger(this.assertionOperationSafety.selector, IMorpho.withdraw.selector);
+        registerFnCallTrigger(this.assertionOperationSafety.selector, IMorpho.repay.selector);
     }
 
-    // Check that supply operation maintains healthy positions
-    function assertionSupply() external {
-        // Get the assertion adopter address
-        IMorpho adopter = IMorpho(ph.getAssertionAdopter());
+    /// @notice Checks that the touched account remains healthy after a lending operation.
+    function assertionOperationSafety() external view {
+        PhEvm.TriggerContext memory ctx = ph.context();
+        PhEvm.ForkId memory postCall = PhEvm.ForkId({forkType: 3, callIndex: ctx.callEnd});
+        (uint256 marketId,) = abi.decode(_stripSelector(ph.callinputAt(ctx.callStart)), (uint256, uint256));
+        address account = _matchingCaller(ctx.selector);
+        bytes32 healthSlot = _healthFactorSlot(marketId, account);
+        uint256 healthFactor = uint256(ph.loadStateAt(ph.getAssertionAdopter(), healthSlot, postCall));
 
-        PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(adopter), adopter.supply.selector);
-        for (uint256 i = 0; i < callInputs.length; i++) {
-            (uint256 marketId,) = abi.decode(callInputs[i].input, (uint256, uint256));
-            address user = callInputs[i].caller;
-
-            IMorpho.MarketParams memory marketParams = adopter.idToMarketParams(marketId);
-
-            require(adopter._isHealthy(marketParams, marketId, user), "Supply operation resulted in unhealthy position");
-        }
+        require(healthFactor >= MIN_HEALTH_FACTOR, "Operation resulted in unhealthy position");
     }
 
-    // Check that borrow operation maintains healthy positions
-    function assertionBorrow() external {
-        // Get the assertion adopter address
-        IMorpho adopter = IMorpho(ph.getAssertionAdopter());
-
-        PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(adopter), adopter.borrow.selector);
-        for (uint256 i = 0; i < callInputs.length; i++) {
-            (uint256 marketId,) = abi.decode(callInputs[i].input, (uint256, uint256));
-            address user = callInputs[i].caller;
-
-            IMorpho.MarketParams memory marketParams = adopter.idToMarketParams(marketId);
-
-            require(adopter._isHealthy(marketParams, marketId, user), "Borrow operation resulted in unhealthy position");
-        }
+    function _matchingCaller(bytes4 selector) internal view returns (address) {
+        PhEvm.TriggerCall[] memory calls = ph.matchingCalls(ph.getAssertionAdopter(), selector, _successfulCalls(), 1);
+        require(calls.length == 1, "missing triggered call");
+        return calls[0].caller;
     }
 
-    // Check that withdraw operation maintains healthy positions
-    function assertionWithdraw() external {
-        // Get the assertion adopter address
-        IMorpho adopter = IMorpho(ph.getAssertionAdopter());
-
-        PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(adopter), adopter.withdraw.selector);
-        for (uint256 i = 0; i < callInputs.length; i++) {
-            (uint256 marketId,) = abi.decode(callInputs[i].input, (uint256, uint256));
-            address user = callInputs[i].caller;
-
-            IMorpho.MarketParams memory marketParams = adopter.idToMarketParams(marketId);
-
-            require(
-                adopter._isHealthy(marketParams, marketId, user), "Withdraw operation resulted in unhealthy position"
-            );
-        }
+    function _successfulCalls() internal pure returns (PhEvm.CallFilter memory filter) {
+        filter.callType = 1;
+        filter.successOnly = true;
     }
 
-    // Check that repay operation maintains healthy positions
-    function assertionRepay() external {
-        // Get the assertion adopter address
-        IMorpho adopter = IMorpho(ph.getAssertionAdopter());
+    function _healthFactorSlot(uint256 marketId, address account) internal pure returns (bytes32) {
+        return keccak256(abi.encode(account, keccak256(abi.encode(marketId, HEALTH_FACTOR_SLOT))));
+    }
 
-        PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(adopter), adopter.repay.selector);
-        for (uint256 i = 0; i < callInputs.length; i++) {
-            (uint256 marketId,) = abi.decode(callInputs[i].input, (uint256, uint256));
-            address user = callInputs[i].caller;
-
-            IMorpho.MarketParams memory marketParams = adopter.idToMarketParams(marketId);
-
-            require(adopter._isHealthy(marketParams, marketId, user), "Repay operation resulted in unhealthy position");
+    function _stripSelector(bytes memory data) internal pure returns (bytes memory) {
+        bytes memory stripped = new bytes(data.length - 4);
+        for (uint256 i = 4; i < data.length; i++) {
+            stripped[i - 4] = data[i];
         }
+        return stripped;
     }
 }
 
-// We use Morpho as an example, but this could be any lending protocol
 interface IMorpho {
-    struct MarketParams {
-        uint256 marketId;
-    }
-
-    struct Position {
-        uint256 supplyShares;
-        uint128 borrowShares;
-        uint128 collateral;
-    }
-
-    function idToMarketParams(uint256) external view returns (MarketParams memory);
-    function position(uint256, address) external view returns (Position memory);
-    function _isHealthy(MarketParams memory marketParams, uint256 marketId, address borrower)
-        external
-        view
-        returns (bool);
-
-    // Functions used in triggers
     function supply(uint256 marketId, uint256 amount) external;
     function borrow(uint256 marketId, uint256 amount) external;
     function withdraw(uint256 marketId, uint256 amount) external;

--- a/snippets/ass8-positions-sum.a.mdx
+++ b/snippets/ass8-positions-sum.a.mdx
@@ -6,65 +6,41 @@ import {Assertion} from "credible-std/Assertion.sol";
 import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
-// Assert that the sum of all positions is the same as the total supply reported by the protocol
 contract PositionSumAssertion is Assertion {
+    bytes32 internal constant TOTAL_SUPPLY_SLOT = bytes32(uint256(0));
+
     constructor() {
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
     function triggers() external view override {
-        // Register trigger for changes to the total supply
         registerFnCallTrigger(this.assertionPositionsSum.selector, ILending.deposit.selector);
     }
 
-    // Compare the sum of all updated positions to the total supply reported by the protocol
-    function assertionPositionsSum() external {
-        // Get the assertion adopter address
-        ILending adopter = ILending(ph.getAssertionAdopter());
+    /// @notice Checks that a deposit call increases stored total supply by the deposited amount.
+    function assertionPositionsSum() external view {
+        address adopter = ph.getAssertionAdopter();
+        PhEvm.TriggerContext memory ctx = ph.context();
+        PhEvm.ForkId memory preCall = PhEvm.ForkId({forkType: 2, callIndex: ctx.callStart});
+        PhEvm.ForkId memory postCall = PhEvm.ForkId({forkType: 3, callIndex: ctx.callEnd});
 
-        // Capture the pre-state total supply
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        uint256 preStateTotalSupply = adopter.totalSupply();
+        uint256 preTotalSupply = uint256(ph.loadStateAt(adopter, TOTAL_SUPPLY_SLOT, preCall));
+        uint256 postTotalSupply = uint256(ph.loadStateAt(adopter, TOTAL_SUPPLY_SLOT, postCall));
+        (, uint256 amount) = abi.decode(_stripSelector(ph.callinputAt(ctx.callStart)), (address, uint256));
 
-        // Execute the transaction
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        require(postTotalSupply == preTotalSupply + amount, "Positions sum does not match total supply");
+    }
 
-        // Get the new total supply
-        uint256 newTotalSupply = adopter.totalSupply();
-
-        // Calculate the expected change in total supply
-        uint256 expectedTotalSupplyChange = newTotalSupply - preStateTotalSupply;
-
-        // Track the actual sum of position changes
-        uint256 positionChangesSum = 0;
-
-        // Get deposit function call inputs
-        PhEvm.CallInputs[] memory callInputs = ph.getCallInputs(address(adopter), adopter.deposit.selector);
-
-        // Process deposit function calls
-        for (uint256 i = 0; i < callInputs.length; i++) {
-            // Decode the function call input
-            (, uint256 amount) = abi.decode(callInputs[i].input, (address, uint256));
-
-            // Add the deposit amount to the position changes sum
-            positionChangesSum += amount;
+    function _stripSelector(bytes memory data) internal pure returns (bytes memory) {
+        bytes memory stripped = new bytes(data.length - 4);
+        for (uint256 i = 4; i < data.length; i++) {
+            stripped[i - 4] = data[i];
         }
-
-        // Note: In a complete implementation, you would also check for withdraw calls
-        // and other functions that modify positions. Ideally, you would have separate
-        // assertion functions for each type of call to make the code more maintainable
-        // and easier to understand.
-
-        // Verify that the sum of position changes equals the change in total supply
-        require(positionChangesSum == expectedTotalSupplyChange, "Positions sum does not match total supply");
+        return stripped;
     }
 }
 
-// We use a simple lending contract as an example
-// Adjust accordingly to the interface of your protocol
 interface ILending {
-    function totalSupply() external view returns (uint256);
-    function balanceOf(address account) external view returns (uint256);
     function deposit(address user, uint256 amount) external;
 }
 ```

--- a/snippets/ass8-positions-sum.a.mdx
+++ b/snippets/ass8-positions-sum.a.mdx
@@ -3,13 +3,18 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 // Assert that the sum of all positions is the same as the total supply reported by the protocol
 contract PositionSumAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     function triggers() external view override {
         // Register trigger for changes to the total supply
-        registerCallTrigger(this.assertionPositionsSum.selector, ILending.deposit.selector);
+        registerFnCallTrigger(this.assertionPositionsSum.selector, ILending.deposit.selector);
     }
 
     // Compare the sum of all updated positions to the total supply reported by the protocol
@@ -18,11 +23,11 @@ contract PositionSumAssertion is Assertion {
         ILending adopter = ILending(ph.getAssertionAdopter());
 
         // Capture the pre-state total supply
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         uint256 preStateTotalSupply = adopter.totalSupply();
 
         // Execute the transaction
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
         // Get the new total supply
         uint256 newTotalSupply = adopter.totalSupply();

--- a/snippets/ass9-timelock-verification.a.mdx
+++ b/snippets/ass9-timelock-verification.a.mdx
@@ -3,12 +3,17 @@
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract TimelockVerificationAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     function triggers() external view override {
         // Register trigger for changes to the timelock storage slot
-        registerStorageChangeTrigger(this.assertionTimelock.selector, bytes32(uint256(0)));
+        registerTxEndTrigger(this.assertionTimelock.selector);
     }
 
     // Verify that a timelock is working as expected after some governance action
@@ -17,7 +22,7 @@ contract TimelockVerificationAssertion is Assertion {
         IGovernance adopter = IGovernance(ph.getAssertionAdopter());
 
         // Get pre-state timelock information
-        ph.forkPreTx();
+        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
         bool preActive = adopter.timelockActive();
 
         // If timelock was already active, no need to check further
@@ -26,7 +31,7 @@ contract TimelockVerificationAssertion is Assertion {
         }
 
         // Get post-state timelock information
-        ph.forkPostTx();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
         // If timelock is now active, verify all parameters
         if (adopter.timelockActive()) {

--- a/snippets/ass9-timelock-verification.a.mdx
+++ b/snippets/ass9-timelock-verification.a.mdx
@@ -21,8 +21,8 @@ contract TimelockVerificationAssertion is Assertion {
     /// @notice Checks that an activated timelock uses a bounded delay.
     function assertionTimelock() external view {
         address adopter = ph.getAssertionAdopter();
-        PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        PhEvm.ForkId memory preFork = _preTx();
+        PhEvm.ForkId memory postFork = _postTx();
 
         bool preActive = uint256(ph.loadStateAt(adopter, TIMELOCK_ACTIVE_SLOT, preFork)) != 0;
         if (preActive) {

--- a/snippets/ass9-timelock-verification.a.mdx
+++ b/snippets/ass9-timelock-verification.a.mdx
@@ -7,53 +7,34 @@ import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract TimelockVerificationAssertion is Assertion {
+    bytes32 internal constant TIMELOCK_DELAY_SLOT = bytes32(uint256(0));
+    bytes32 internal constant TIMELOCK_ACTIVE_SLOT = bytes32(uint256(1));
+
     constructor() {
         registerAssertionSpec(AssertionSpec.Reshiram);
     }
 
     function triggers() external view override {
-        // Register trigger for changes to the timelock storage slot
         registerTxEndTrigger(this.assertionTimelock.selector);
     }
 
-    // Verify that a timelock is working as expected after some governance action
-    function assertionTimelock() external {
-        // Get the assertion adopter address
-        IGovernance adopter = IGovernance(ph.getAssertionAdopter());
-
-        // Get pre-state timelock information
+    /// @notice Checks that an activated timelock uses a bounded delay.
+    function assertionTimelock() external view {
+        address adopter = ph.getAssertionAdopter();
         PhEvm.ForkId memory preFork = PhEvm.ForkId({forkType: 0, callIndex: 0});
-        bool preActive = adopter.timelockActive();
+        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
 
-        // If timelock was already active, no need to check further
+        bool preActive = uint256(ph.loadStateAt(adopter, TIMELOCK_ACTIVE_SLOT, preFork)) != 0;
         if (preActive) {
             return;
         }
 
-        // Get post-state timelock information
-        PhEvm.ForkId memory postFork = PhEvm.ForkId({forkType: 1, callIndex: 0});
+        bool postActive = uint256(ph.loadStateAt(adopter, TIMELOCK_ACTIVE_SLOT, postFork)) != 0;
+        if (postActive) {
+            uint256 delay = uint256(ph.loadStateAt(adopter, TIMELOCK_DELAY_SLOT, postFork));
 
-        // If timelock is now active, verify all parameters
-        if (adopter.timelockActive()) {
-            // Verify timelock delay is within acceptable bounds
-            bool minDelayCorrect = adopter.timelockDelay() >= 1 days;
-            bool maxDelayCorrect = adopter.timelockDelay() <= 2 weeks;
-
-            // Require all parameters to be correct
-            require(minDelayCorrect && maxDelayCorrect, "Timelock parameters invalid");
+            require(delay >= 1 days && delay <= 2 weeks, "Timelock parameters invalid");
         }
     }
-}
-
-interface IGovernance {
-    struct Timelock {
-        uint256 timelockDelay;
-        bool isActive;
-    }
-
-    function timelockActive() external view returns (bool);
-    function timelockDelay() external view returns (uint256);
-    function activateTimelock() external;
-    function setTimelock(uint256 _delay) external;
 }
 ```

--- a/snippets/phylax-assertions-rules.mdx
+++ b/snippets/phylax-assertions-rules.mdx
@@ -95,28 +95,30 @@ forge-std/=lib/forge-std/src/
 pragma solidity ^0.8.13;
 
 import {Assertion} from "credible-std/Assertion.sol";
+import {AssertionSpec} from "credible-std/SpecRecorder.sol";
 import {PhEvm} from "credible-std/PhEvm.sol";
 
 contract ProtocolAssertion is Assertion {
+    constructor() {
+        registerAssertionSpec(AssertionSpec.Reshiram);
+    }
+
     // Required: Register triggers for assertion functions
     function triggers() external view override {
-        registerCallTrigger(this.assertionFunction.selector, Protocol.functionToMonitor.selector);
+        registerFnCallTrigger(this.assertionFunction.selector, Protocol.functionToMonitor.selector);
     }
 
     // Assertion function - must be public/external
-    function assertionFunction() external {
+    function assertionFunction() external view {
         // Get protocol instance
         Protocol protocol = Protocol(ph.getAssertionAdopter());
 
-        // State comparison logic
-        ph.forkPreTx();
-        // ... pre-state logic
-
-        ph.forkPostTx();
-        // ... post-state logic
+        // State comparison logic with explicit Reshiram snapshots
+        uint256 preValue = uint256(ph.loadStateAt(address(protocol), SOME_VALUE_SLOT, PhEvm.ForkId({forkType: 0, callIndex: 0})));
+        uint256 postValue = uint256(ph.loadStateAt(address(protocol), SOME_VALUE_SLOT, PhEvm.ForkId({forkType: 1, callIndex: 0})));
 
         // Require statements for invariants
-        require(condition, "Descriptive error message");
+        require(postValue >= preValue, "Descriptive error message");
     }
 }
 ```
@@ -125,10 +127,11 @@ contract ProtocolAssertion is Assertion {
 
 #### State Management
 
-- `ph.forkPreTx()` - Snapshot before transaction
-- `ph.forkPostTx()` - Snapshot after transaction
-- `ph.forkPreCall(callId)` - Snapshot before specific call
-- `ph.forkPostCall(callId)` - Snapshot after specific call
+- `PhEvm.ForkId({forkType: 0, callIndex: 0})` - Snapshot ID for state before the transaction
+- `PhEvm.ForkId({forkType: 1, callIndex: 0})` - Snapshot ID for state after the transaction
+- `PhEvm.ForkId({forkType: 2, callIndex: callId})` - Snapshot ID for state before a specific call
+- `PhEvm.ForkId({forkType: 3, callIndex: callId})` - Snapshot ID for state after a specific call
+- `ph.loadStateAt(target, slot, fork)` - Read storage at a snapshot
 
 #### Call Input Tracking
 
@@ -150,8 +153,8 @@ contract ProtocolAssertion is Assertion {
 
 #### Storage Access
 
-- `ph.load(address, bytes32)` - Read storage from an address at a specific slot
-- **Note**: Use `ph.load()` not `vm.load()` - the `vm` cheatcode is not available in assertions
+- `ph.loadStateAt(address, bytes32, fork)` - Read storage from an address at a specific snapshot
+- **Note**: Use `ph.loadStateAt()` not `vm.load()` - the `vm` cheatcode is not available in assertions
 - Useful for reading internal state variables that aren't exposed as public functions
 
 #### Console Logs
@@ -175,29 +178,20 @@ contract ProtocolAssertion is Assertion {
 ```solidity
 function triggers() external view override {
     // Single function trigger
-    registerCallTrigger(this.assertionFunction.selector, Protocol.functionToMonitor.selector);
+    registerFnCallTrigger(this.assertionFunction.selector, Protocol.functionToMonitor.selector);
 
     // Multiple functions trigger same assertion
-    registerCallTrigger(this.assertionFunction.selector, Protocol.function1.selector);
-    registerCallTrigger(this.assertionFunction.selector, Protocol.function2.selector);
+    registerFnCallTrigger(this.assertionFunction.selector, Protocol.function1.selector);
+    registerFnCallTrigger(this.assertionFunction.selector, Protocol.function2.selector);
 }
 ```
 
-#### Storage Change Triggers
+#### Transaction End Triggers
 
 ```solidity
 function triggers() external view override {
-    // Trigger on specific storage slot changes
-    registerStorageChangeTrigger(this.assertionFunction.selector, bytes32(uint256(0)));
-}
-```
-
-#### Balance Change Triggers
-
-```solidity
-function triggers() external view override {
-    // Trigger on balance changes
-    registerBalanceChangeTrigger(this.assertionFunction.selector, address(0x...));
+    // Trigger after transactions that touch the protected contract
+    registerTxEndTrigger(this.assertionFunction.selector);
 }
 ```
 
@@ -206,14 +200,11 @@ function triggers() external view override {
 #### Pre/Post State Comparison
 
 ```solidity
-function assertionStateInvariant() external {
+function assertionStateInvariant() external view {
     Protocol protocol = Protocol(ph.getAssertionAdopter());
 
-    ph.forkPreTx();
-    uint256 preValue = protocol.someValue();
-
-    ph.forkPostTx();
-    uint256 postValue = protocol.someValue();
+    uint256 preValue = uint256(ph.loadStateAt(address(protocol), SOME_VALUE_SLOT, PhEvm.ForkId({forkType: 0, callIndex: 0})));
+    uint256 postValue = uint256(ph.loadStateAt(address(protocol), SOME_VALUE_SLOT, PhEvm.ForkId({forkType: 1, callIndex: 0})));
 
     require(postValue >= preValue, "Value cannot decrease");
 }
@@ -244,15 +235,12 @@ function assertionCallValidation() external {
 #### Multi-Layered Validation
 
 ```solidity
-function assertionComplexInvariant() external {
+function assertionComplexInvariant() external view {
     Protocol protocol = Protocol(ph.getAssertionAdopter());
 
     // Layer 1: Basic state check (cheapest)
-    ph.forkPreTx();
-    uint256 preBalance = protocol.balance();
-
-    ph.forkPostTx();
-    uint256 postBalance = protocol.balance();
+    uint256 preBalance = uint256(ph.loadStateAt(address(protocol), BALANCE_SLOT, PhEvm.ForkId({forkType: 0, callIndex: 0})));
+    uint256 postBalance = uint256(ph.loadStateAt(address(protocol), BALANCE_SLOT, PhEvm.ForkId({forkType: 1, callIndex: 0})));
 
     if (postBalance < preBalance) {
         // Layer 2: Detailed analysis only if basic check fails
@@ -275,20 +263,16 @@ function assertionComplexInvariant() external {
 #### Intra-Transaction State Monitoring
 
 ```solidity
-function assertionIntraTxOracleDeviation() external {
+function assertionIntraTxOracleDeviation() external view {
     IOracle oracle = IOracle(ph.getAssertionAdopter());
 
-    // Get initial state before transaction
-    ph.forkPreTx();
-    uint256 initialPrice = oracle.price();
+    uint256 initialPrice = uint256(ph.loadStateAt(address(oracle), PRICE_SLOT, PhEvm.ForkId({forkType: 0, callIndex: 0})));
 
     // Calculate allowed deviation thresholds
     uint256 maxAllowedPrice = (initialPrice * 110) / 100; // +10%
     uint256 minAllowedPrice = (initialPrice * 90) / 100;  // -10%
 
-    // Check final state after transaction
-    ph.forkPostTx();
-    uint256 finalPrice = oracle.price();
+    uint256 finalPrice = uint256(ph.loadStateAt(address(oracle), PRICE_SLOT, PhEvm.ForkId({forkType: 1, callIndex: 0})));
     require(
         finalPrice >= minAllowedPrice && finalPrice <= maxAllowedPrice,
         "Oracle final price deviation exceeds threshold"
@@ -302,11 +286,11 @@ function assertionIntraTxOracleDeviation() external {
 
     // Check each intermediate state after each call
     for (uint256 i = 0; i < priceUpdates.length; i++) {
-        // Snapshot state after this specific call
-        ph.forkPostCall(priceUpdates[i].id);
-
-        // Check price at this point in the transaction
-        uint256 intermediatePrice = oracle.price();
+        uint256 intermediatePrice = uint256(ph.loadStateAt(
+            address(oracle),
+            PRICE_SLOT,
+            PhEvm.ForkId({forkType: 3, callIndex: priceUpdates[i].id})
+        ));
         require(
             intermediatePrice >= minAllowedPrice && intermediatePrice <= maxAllowedPrice,
             "Oracle intra-tx price deviation exceeds threshold"
@@ -600,10 +584,10 @@ PhEvm.CallInputs[] memory calls = ph.getCallInputs(target, selector);
 
 ```solidity
 // ❌ WRONG: Using wrong selector or bytes signature
-registerCallTrigger(this.assertionFunction.selector, bytes4(0x12345678));
+registerFnCallTrigger(this.assertionFunction.selector, bytes4(0x12345678));
 
 // ✅ CORRECT: Use actual name of function selector
-registerCallTrigger(this.assertionFunction.selector, Protocol.targetFunction.selector);
+registerFnCallTrigger(this.assertionFunction.selector, Protocol.targetFunction.selector);
 ```
 
 ### Missing Error Messages

--- a/snippets/phylax-assertions-rules.mdx
+++ b/snippets/phylax-assertions-rules.mdx
@@ -114,8 +114,8 @@ contract ProtocolAssertion is Assertion {
         Protocol protocol = Protocol(ph.getAssertionAdopter());
 
         // State comparison logic with explicit Reshiram snapshots
-        uint256 preValue = uint256(ph.loadStateAt(address(protocol), SOME_VALUE_SLOT, PhEvm.ForkId({forkType: 0, callIndex: 0})));
-        uint256 postValue = uint256(ph.loadStateAt(address(protocol), SOME_VALUE_SLOT, PhEvm.ForkId({forkType: 1, callIndex: 0})));
+        uint256 preValue = uint256(ph.loadStateAt(address(protocol), SOME_VALUE_SLOT, _preTx()));
+        uint256 postValue = uint256(ph.loadStateAt(address(protocol), SOME_VALUE_SLOT, _postTx()));
 
         // Require statements for invariants
         require(postValue >= preValue, "Descriptive error message");
@@ -127,8 +127,8 @@ contract ProtocolAssertion is Assertion {
 
 #### State Management
 
-- `PhEvm.ForkId({forkType: 0, callIndex: 0})` - Snapshot ID for state before the transaction
-- `PhEvm.ForkId({forkType: 1, callIndex: 0})` - Snapshot ID for state after the transaction
+- `_preTx()` - Snapshot ID for state before the transaction
+- `_postTx()` - Snapshot ID for state after the transaction
 - `PhEvm.ForkId({forkType: 2, callIndex: callId})` - Snapshot ID for state before a specific call
 - `PhEvm.ForkId({forkType: 3, callIndex: callId})` - Snapshot ID for state after a specific call
 - `ph.loadStateAt(target, slot, fork)` - Read storage at a snapshot
@@ -203,8 +203,8 @@ function triggers() external view override {
 function assertionStateInvariant() external view {
     Protocol protocol = Protocol(ph.getAssertionAdopter());
 
-    uint256 preValue = uint256(ph.loadStateAt(address(protocol), SOME_VALUE_SLOT, PhEvm.ForkId({forkType: 0, callIndex: 0})));
-    uint256 postValue = uint256(ph.loadStateAt(address(protocol), SOME_VALUE_SLOT, PhEvm.ForkId({forkType: 1, callIndex: 0})));
+    uint256 preValue = uint256(ph.loadStateAt(address(protocol), SOME_VALUE_SLOT, _preTx()));
+    uint256 postValue = uint256(ph.loadStateAt(address(protocol), SOME_VALUE_SLOT, _postTx()));
 
     require(postValue >= preValue, "Value cannot decrease");
 }
@@ -239,8 +239,8 @@ function assertionComplexInvariant() external view {
     Protocol protocol = Protocol(ph.getAssertionAdopter());
 
     // Layer 1: Basic state check (cheapest)
-    uint256 preBalance = uint256(ph.loadStateAt(address(protocol), BALANCE_SLOT, PhEvm.ForkId({forkType: 0, callIndex: 0})));
-    uint256 postBalance = uint256(ph.loadStateAt(address(protocol), BALANCE_SLOT, PhEvm.ForkId({forkType: 1, callIndex: 0})));
+    uint256 preBalance = uint256(ph.loadStateAt(address(protocol), BALANCE_SLOT, _preTx()));
+    uint256 postBalance = uint256(ph.loadStateAt(address(protocol), BALANCE_SLOT, _postTx()));
 
     if (postBalance < preBalance) {
         // Layer 2: Detailed analysis only if basic check fails
@@ -266,13 +266,13 @@ function assertionComplexInvariant() external view {
 function assertionIntraTxOracleDeviation() external view {
     IOracle oracle = IOracle(ph.getAssertionAdopter());
 
-    uint256 initialPrice = uint256(ph.loadStateAt(address(oracle), PRICE_SLOT, PhEvm.ForkId({forkType: 0, callIndex: 0})));
+    uint256 initialPrice = uint256(ph.loadStateAt(address(oracle), PRICE_SLOT, _preTx()));
 
     // Calculate allowed deviation thresholds
     uint256 maxAllowedPrice = (initialPrice * 110) / 100; // +10%
     uint256 minAllowedPrice = (initialPrice * 90) / 100;  // -10%
 
-    uint256 finalPrice = uint256(ph.loadStateAt(address(oracle), PRICE_SLOT, PhEvm.ForkId({forkType: 1, callIndex: 0})));
+    uint256 finalPrice = uint256(ph.loadStateAt(address(oracle), PRICE_SLOT, _postTx()));
     require(
         finalPrice >= minAllowedPrice && finalPrice <= maxAllowedPrice,
         "Oracle final price deviation exceeds threshold"


### PR DESCRIPTION
## Summary
- keep the updated Reshiram v2 snippets in a clearer Diataxis shape: assertion pages stay example/reference-style, `credible-std` stays reference, and install details stay in the install guide
- restore the Assertions Book catalog/nav entries that were dropped in the branch
- move Assertions Book source links and the snippet import workflow from deprecated `assertion-examples` to `credible-std/examples/assertions-book`
- fix the ERC4626 deposit/withdraw snippet so `callStart`/`callEnd` match the current `PhEvm.TriggerContext` type

## Related PRs
- Depends on phylaxsystems/credible-std#62 for the new canonical example directory
- Deprecates the old source repo in phylaxsystems/assertion-examples#24

## Verification
- `pnpm validate`
- `pnpm broken-links`
- canonical snippets match `credible-std/examples/assertions-book/assertions/src` using the import workflow format